### PR TITLE
Fix for double quotes

### DIFF
--- a/Csv/CsvReader.cs
+++ b/Csv/CsvReader.cs
@@ -145,7 +145,7 @@ namespace Csv
             lock (syncRoot)
             {
                 if (!splitterCache.TryGetValue(options.Separator, out splitter))
-                    splitterCache[options.Separator] = splitter = new Regex(string.Format(@"(?>(?(IQ)(?(ESC).(?<-ESC>)|\\(?<ESC>))|(?!))|(?(IQ)\k<QUOTE>(?<-IQ>)|(?<QUOTE>"")(?<IQ>))|(?(IQ).|[^{0}]))+|^(?={0})|(?<={0})(?={0})|(?<={0})$", Regex.Escape(options.Separator.ToString())), (RegexOptions)8);
+                    splitterCache[options.Separator] = splitter = new Regex(string.Format(@"(?>(?(IQ)(?(ESC).(?<-ESC>)|\\(?<ESC>))|(?!))|(?(IQ)\k<QUOTE>(?<-IQ>)|(?<QUOTE>"""")(?<IQ>))|(?(IQ).|[^{0}]))+|^(?={0})|(?<={0})(?={0})|(?<={0})$", Regex.Escape(options.Separator.ToString())), (RegexOptions)8);
             }
 
             options.Splitter = splitter;


### PR DESCRIPTION
Fix for double quotes see:
http://regexstorm.net/tester
current: (?>(?(IQ)(?(ESC).(?<-ESC>)|\\(?<ESC>))|(?!))|(?(IQ)\k<QUOTE>(?<-IQ>)|(?<QUOTE>")(?<IQ>))|(?(IQ).|[^,]))+|^(?=,)|(?<=,)(?=,)|(?<=,)$
update: (?>(?(IQ)(?(ESC).(?<-ESC>)|\\(?<ESC>))|(?!))|(?(IQ)\k<QUOTE>(?<-IQ>)|(?<QUOTE>"")(?<IQ>))|(?(IQ).|[^,]))+|^(?=,)|(?<=,)(?=,)|(?<=,)$

Input: Level1,CPC200 T&B STRUT COBRA PIPECLAMP 2",1,1.84915,199