### PR TITLE
Allow user to retrieve all values from a CSV Line.

### DIFF
--- a/Csv/CsvReader.cs
+++ b/Csv/CsvReader.cs
@@ -210,6 +210,7 @@ namespace Csv
                 Headers = headers;
                 Raw = raw;
                 Index = index;
+                Values = Line;
             }
 
             public string[] Headers { get; }
@@ -221,6 +222,8 @@ namespace Csv
             public int ColumnCount => Line.Length;
 
             public bool HasColumn(string name) => headerLookup.TryGetValue(name, out _);
+
+            public string[] Values { get; }
 
             private string[] Line
             {

--- a/Csv/CsvReader.cs
+++ b/Csv/CsvReader.cs
@@ -210,7 +210,6 @@ namespace Csv
                 Headers = headers;
                 Raw = raw;
                 Index = index;
-                Values = Line;
             }
 
             public string[] Headers { get; }
@@ -223,7 +222,7 @@ namespace Csv
 
             public bool HasColumn(string name) => headerLookup.TryGetValue(name, out _);
 
-            public string[] Values { get; }
+            public string[] Values => Line;
 
             private string[] Line
             {

--- a/Csv/ICsvLine.cs
+++ b/Csv/ICsvLine.cs
@@ -11,6 +11,11 @@ namespace Csv
         string[] Headers { get; }
 
         /// <summary>
+        /// Gets a list of values in string format for the current row.
+        /// </summary>
+        string[] Values { get; }
+
+        /// <summary>
         /// Gets the original raw content of the line.
         /// </summary>
         string Raw { get; }


### PR DESCRIPTION
This change exposes the `Line` method in the sealed class that implements `ICsvLine`, so the users can extract all values from a particular row. The extracted values are going to be returned in string format, so we leave the user the option to cast/parse values when needed instead of being complex and clever to identify the type of a particular element.

This is a common operation when someone/something deals with CSV Files. Sometimes it's necessary to have a collection of values for particular row(s).