### PR TITLE
Fix multiline parsing bugs; add tests

### DIFF
--- a/Csv.Tests/Tests.cs
+++ b/Csv.Tests/Tests.cs
@@ -296,6 +296,54 @@ namespace Csv.Tests
         }
 
         [TestMethod]
+        public void WithNewLineInQuotedFieldValue_MultipleRecordsHandledCorrectly()
+        {
+            const string input = @"ID,Notes,User
+2,"" * Bullet 1
+* Bullet 2
+* Bullet 3
+* Bullet 4
+* Bullet 5
+"",Joe
+3,""* Bullet 1
+* Bullet 2
+* Bullet 3
+* Bullet 4
+* Bullet 5
+"",Joe
+";
+            var options = new CsvOptions { AllowNewLineInEnclosedFieldValues = true };
+            var records = CsvReader.ReadFromText(input, options).ToArray();
+            Assert.AreEqual(2, records.Length);
+            Assert.AreEqual(3, records[0].ColumnCount);
+            Assert.AreEqual(3, records[0].ColumnCount);
+        }
+
+        [TestMethod]
+        public void WithNewLineWithDelimiterInQuotedFieldValue_MultipleRecordsHandledCorrectly()
+        {
+            const string input = @"ID,Notes,User
+2,"" * Bullet 1,
+* Bullet 2,
+* Bullet 3,
+* Bullet 4,
+* Bullet 5,
+"",Joe
+3,""* Bullet 1,
+* Bullet 2,
+* Bullet 3,
+* Bullet 4,
+* Bullet 5,
+"",Joe
+";
+            var options = new CsvOptions { AllowNewLineInEnclosedFieldValues = true };
+            var records = CsvReader.ReadFromText(input, options).ToArray();
+            Assert.AreEqual(2, records.Length);
+            Assert.AreEqual(3, records[0].ColumnCount);
+            Assert.AreEqual(3, records[0].ColumnCount);
+        }
+
+        [TestMethod]
         [ExpectedException(typeof(ArgumentOutOfRangeException))]
         public void ThrowExceptionForUnknownHeaders()
         {

--- a/Csv/CsvReader.cs
+++ b/Csv/CsvReader.cs
@@ -138,8 +138,7 @@ namespace Csv
                 var record = new ReadLine(headers, headerLookup, index, line, options);
                 if (options.AllowNewLineInEnclosedFieldValues)
                 {
-                    var lastField = record.RawSplitLine.Last();
-                    while (IsUnterminatedQuotedValue(lastField, options))
+                    while (record.RawSplitLine.Any(f => IsUnterminatedQuotedValue(f, options)))
                     {
                         var nextLine = reader.ReadLine();
                         if (nextLine == null)
@@ -250,7 +249,7 @@ namespace Csv
             {
                 quoteChar = '"';
             }
-            else if(options.AllowSingleQuoteToEncloseFieldValues && value.StartsWith("'"))
+            else if (options.AllowSingleQuoteToEncloseFieldValues && value.StartsWith("'"))
             {
                 quoteChar = '\'';
             }

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ _More examples can be found in the tests._
 ### Reading a CSV file
 
 ```csharp
-// NOTE: Library assumes that the csv data will have a header row
+// NOTE: Library assumes that the csv data will have a header row by default, see CsvOptions.HeaderMode
 /*
 # comments are ignored
 Column name,Second column,Third column
@@ -29,6 +29,8 @@ foreach (var line in CsvReader.ReadFromText(csv))
     var byName = line["Column name"];
 }
 ```
+
+`CsvReader` also supports reading from a `TextReader` (`CsvReader.Read(TextReader, CsvOptions)`) or a `Stream` (`CsvReader.ReadFromStream(Stream, CsvOptions)`)
 
 `CsvOptions` can be used to configure the csv parsing:
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,11 @@ To install csv, use the following command in the Package Manager Console
 
     PM> Install-Package Csv
 
-## Usage
+## Basic Usage
+
+_More examples can be found in the tests._
+
+### Reading a CSV file
 
 ```csharp
 // NOTE: Library assumes that the csv data will have a header row
@@ -26,7 +30,8 @@ foreach (var line in CsvReader.ReadFromText(csv))
 }
 ```
 
-CsvOptions can be used to configured the csv parsing:
+`CsvOptions` can be used to configure the csv parsing:
+
 ```csharp
 var options = new CsvOptions // Defaults
 {
@@ -39,10 +44,32 @@ var options = new CsvOptions // Defaults
     ValidateColumnCount = false, // Checks each row immediately for column count
     ReturnEmptyForMissingColumn = false, // Allows for accessing invalid column names
     Aliases = null, // A collection of alternative column names
+    AllowNewLineInEnclosedFieldValues = false, // Respects new line (either \r\n or \n) characters inside field values enclosed in double quotes.
+    AllowBackSlashToEscapeQuote = false, // Allows the sequence "\"" to be a valid quoted value (in addition to the standard """")
+    AllowSingleQuoteToEncloseFieldValues = false, // Allows the single-quote character to be used to enclose field values
+    NewLine = Environment.NewLine // The new line string to use when multiline field values are read (Requires "AllowNewLineInEnclosedFieldValues" to be set to "true" for this to have any effect.)
 };
 ```
 
-More examples can be found in the tests.
+### Writing a CSV file
+
+```csharp
+var columnNames = new [] { "Id", "Name" };
+var rows = new [] 
+{
+    new [] { "0", "John Doe" },
+    new [] { "1", "Jane Doe" }
+};
+var csv = CsvWriter.WriteToText(columnNames, rows, ',');
+File.WriteAllText("people.csv", csv);
+/*
+Writes the following to the file:
+
+Id,Name
+0,John Doe
+1,Jane Doe
+*/
+```
 
 
 ## Build status


### PR DESCRIPTION
After the merge and release of #11, I came across some additional use cases that didn't work.  I've added tests that cover those use cases, and fixed it so it behaves the way library consumers would expect.

While I was at it, I also updated the documentation to include the new `CsvOptions` introduced in my last PR, and added a section explaining how to use `CsvWriter`.

Could this possibly close #6 as well? (the library is so simple that I don't think you need to go full on DocFx for it)