### PR TITLE
fix: Fix writer null cell (#74)

### DIFF
--- a/Csv/CsvWriter.cs
+++ b/Csv/CsvWriter.cs
@@ -129,7 +129,7 @@ namespace Csv
                 if (i < data.Length)
                 {
                     var escape = false;
-                    var cell = data[i];
+                    var cell = data[i] ?? string.Empty;
 #if NET8_0_OR_GREATER
                     if (cell.Contains('"'))
 #else


### PR DESCRIPTION
## Summary
- fix crash when writing null string data in CsvWriter

## Testing
- `dotnet test` *(fails: Assert.AreEqual due to newline differences)*