### PR TITLE
feat: Add AllowEnclosedFieldValues option (#51)

### DIFF
--- a/Csv.Tests/Tests.cs
+++ b/Csv.Tests/Tests.cs
@@ -423,6 +423,17 @@ namespace Csv.Tests
         }
 
         [TestMethod]
+        public void DisableQuoteParsingTreatsQuotesAsData()
+        {
+            var input = "h1\th2\th3\r\n1\t\"2\" is 2\t3";
+            var options = new CsvOptions { Separator = '\t', AllowEnclosedFieldValues = false };
+            var lines = CsvReader.ReadFromText(input, options).ToArray();
+            Assert.AreEqual(1, lines.Length);
+            Assert.AreEqual("\"2\" is 2", lines[0]["h2"]);
+            Assert.AreEqual("3", lines[0]["h3"]);
+        }
+
+        [TestMethod]
         public void WithAllowNewLineInEnclosedFieldValues_AllowLFInsideQuotedValue()
         {
             var options = new CsvOptions

--- a/Csv/CsvLineSplitter.cs
+++ b/Csv/CsvLineSplitter.cs
@@ -26,7 +26,7 @@ namespace Csv
 
         public static bool IsUnterminatedQuotedValue(SpanText value, CsvOptions options)
         {
-            if (value.Length == 0)
+            if (value.Length == 0 || !options.AllowEnclosedFieldValues)
                 return false;
 
             char quoteChar;
@@ -112,7 +112,7 @@ namespace Csv
                         values.Add(value);
                         start = i + 1;
                     }
-                    else if ((ch == '"' || (options.AllowSingleQuoteToEncloseFieldValues && ch == '\'')) && i == start)
+                    else if (options.AllowEnclosedFieldValues && (ch == '"' || (options.AllowSingleQuoteToEncloseFieldValues && ch == '\'')) && i == start)
                     {
                         inQuotes = true;
                         quoteChar = ch;

--- a/Csv/CsvOptions.cs
+++ b/Csv/CsvOptions.cs
@@ -79,6 +79,12 @@ namespace Csv
         public bool AllowSingleQuoteToEncloseFieldValues { get; set; }
 
         /// <summary>
+        /// Allows field values to be enclosed in quotes. When set to <c>false</c> quotes
+        /// will be treated as normal characters, defaults to <c>true</c>.
+        /// </summary>
+        public bool AllowEnclosedFieldValues { get; set; } = true;
+
+        /// <summary>
         /// The new line string to use when multiline field values are read, defaults to <see cref="Environment.NewLine"/>.
         /// </summary>
         /// <remarks>

--- a/Csv/CsvReader.cs
+++ b/Csv/CsvReader.cs
@@ -349,17 +349,18 @@ namespace Csv
                 if (options.TrimData)
                     str = str.Trim();
 
-                if (str.Length > 1)
+                if (str.Length > 1 && options.AllowEnclosedFieldValues)
                 {
 #if NET8_0_OR_GREATER
-                    if (str.Span[0] == '"' && str.Span[^1] == '"')
+                    var span = str.Span;
+                    if (span[0] == '"' && span[^1] == '"')
                     {
                         str = str[1..^1].Unescape('"', '"');
 
                         if (options.AllowBackSlashToEscapeQuote)
                             str = str.Unescape('\\', '"');
                     }
-                    else if (options.AllowSingleQuoteToEncloseFieldValues && str.Span[0] == '\'' && str.Span[^1] == '\'')
+                    else if (options.AllowSingleQuoteToEncloseFieldValues && span[0] == '\'' && span[^1] == '\'')
                         str = str[1..^1];
 #else
                     if (str[0] == '"' && str[str.Length - 1] == '"')


### PR DESCRIPTION
## Summary
- allow opting out of quoted field parsing
- cover this new option in tests

## Testing
- `dotnet test --no-build --logger "console;verbosity=normal" -v m` *(fails: EmptyCsv, HeaderOnly, HeaderAndRows, HeaderAndRowsWithNotEnoughColumns, HeaderAndRowsEscapedValues, DontEscapeCommaForCustomSeparator)*