### PR TITLE
Add test for comma in quoted text

### DIFF
--- a/Csv.Tests/IssuesTests.cs
+++ b/Csv.Tests/IssuesTests.cs
@@ -1,0 +1,29 @@
+using System.Linq;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Csv.Tests
+{
+    [TestClass]
+    public class IssuesTests
+    {
+        [TestMethod]
+        [TestCategory("Issues")]
+        public void Issue_73_EndingCommaInQuotedTextFails()
+        {
+            var options = new CsvOptions
+            {
+                Separator = ',',
+                HeaderMode = HeaderMode.HeaderAbsent,
+                AllowNewLineInEnclosedFieldValues = true,
+            };
+            string input = """Normal,"quoted with nested ""double"" quotes, and comma at the end,",normal 3,normal 4,normal 5""";
+            var data = CsvReader.ReadFromText(input, options).First();
+            Assert.AreEqual(5, data.ColumnCount);
+            Assert.AreEqual("Normal", data[0]);
+            Assert.AreEqual("quoted with nested \"double\" quotes, and comma at the end,", data[1]);
+            Assert.AreEqual("normal 3", data[2]);
+            Assert.AreEqual("normal 4", data[3]);
+            Assert.AreEqual("normal 5", data[4]);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add regression test covering comma at the end of a quoted field

## Testing
- `dotnet test Csv.Tests/Csv.Tests.csproj --filter FullyQualifiedName~Issue73Tests -v minimal`
- `dotnet test Csv.sln -v minimal` *(fails: 6 failed, 67 passed)*