### PR TITLE
Add async and skip-header tests

### DIFF
--- a/Csv.Tests/Tests.cs
+++ b/Csv.Tests/Tests.cs
@@ -2,6 +2,8 @@ using System;
 using System.IO;
 using System.Linq;
 using System.Text;
+using System.Collections.Generic;
+using System.Threading.Tasks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Csv.Tests
@@ -753,6 +755,34 @@ namespace Csv.Tests
             Assert.AreEqual("Never", block[1]["C"]);
             Assert.AreEqual("89.64", block[2]["B"]);
             Assert.AreEqual("gonna", block[2]["C"]);
+        }
+
+        [TestMethod]
+        public async Task ReadFromTextAsyncMatchesSync()
+        {
+            const string csv = "A,B\n1,2\n3,4";
+            var sync = CsvReader.ReadFromText(csv).ToArray();
+            var asyncLines = new List<ICsvLine>();
+            await foreach (var line in CsvReader.ReadFromTextAsync(csv))
+                asyncLines.Add(line);
+
+            Assert.AreEqual(sync.Length, asyncLines.Count);
+            for (var i = 0; i < sync.Length; i++)
+                CollectionAssert.AreEqual(sync[i].Values, asyncLines[i].Values);
+        }
+
+        [TestMethod]
+        public async Task ReadFromStreamAsyncMatchesSync()
+        {
+            const string csv = "A,B\n1,2\n3,4";
+            var sync = CsvReader.ReadFromStream(new MemoryStream(Encoding.UTF8.GetBytes(csv))).ToArray();
+            var asyncLines = new List<ICsvLine>();
+            await foreach (var line in CsvReader.ReadFromStreamAsync(new MemoryStream(Encoding.UTF8.GetBytes(csv))))
+                asyncLines.Add(line);
+
+            Assert.AreEqual(sync.Length, asyncLines.Count);
+            for (var i = 0; i < sync.Length; i++)
+                CollectionAssert.AreEqual(sync[i].Values, asyncLines[i].Values);
         }
     }
 }

--- a/Csv.Tests/WriterTests.cs
+++ b/Csv.Tests/WriterTests.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using Microsoft.VisualStudio.TestTools.UnitTesting;


### PR DESCRIPTION
## Summary
- add tests for skipHeaderRow and async writer methods
- add async read tests for CsvReader

## Testing
- `dotnet build Csv.Tests/Csv.Tests.csproj`
- `dotnet test --no-build --logger "console;verbosity=minimal"` *(fails: 6, Passed: 71, Total: 77)*