### PR TITLE
Fix newline dependent tests

### DIFF
--- a/Csv.Tests/WriterTests.cs
+++ b/Csv.Tests/WriterTests.cs
@@ -2,6 +2,7 @@
 using System.IO;
 using System.Linq;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
 
 namespace Csv.Tests
 {
@@ -11,31 +12,34 @@ namespace Csv.Tests
         [TestMethod]
         public void EmptyCsv()
         {
-            CheckOutput([], [], "\r\n");
+            CheckOutput([], [], Environment.NewLine);
         }
 
         [TestMethod]
         public void HeaderOnly()
         {
-            CheckOutput(["A", "B", "C"], [], "A,B,C\r\n");
+            CheckOutput(["A", "B", "C"], [], $"A,B,C{Environment.NewLine}");
         }
 
         [TestMethod]
         public void HeaderAndRows()
         {
-            CheckOutput(["A", "B", "C"], Enumerable.Repeat(new[] { "X", "Y", "Z" }, 2), "A,B,C\r\nX,Y,Z\r\nX,Y,Z\r\n");
+            CheckOutput(["A", "B", "C"], Enumerable.Repeat(new[] { "X", "Y", "Z" }, 2),
+                $"A,B,C{Environment.NewLine}X,Y,Z{Environment.NewLine}X,Y,Z{Environment.NewLine}");
         }
 
         [TestMethod]
         public void HeaderAndRowsWithNotEnoughColumns()
         {
-            CheckOutput(["A", "B", "C"], Enumerable.Repeat(new[] { "X" }, 2), "A,B,C\r\nX,,\r\nX,,\r\n");
+            CheckOutput(["A", "B", "C"], Enumerable.Repeat(new[] { "X" }, 2),
+                $"A,B,C{Environment.NewLine}X,,{Environment.NewLine}X,,{Environment.NewLine}");
         }
 
         [TestMethod]
         public void HeaderAndRowsEscapedValues()
         {
-            CheckOutput(["A,", "\"B", "C\"", "D'"], Enumerable.Repeat(new[] { "X", "Y", "Z" }, 2), "\"A,\",\"\"\"B\",\"C\"\"\",\"D'\"\r\nX,Y,Z,\r\nX,Y,Z,\r\n");
+            CheckOutput(["A,", "\"B", "C\"", "D'"], Enumerable.Repeat(new[] { "X", "Y", "Z" }, 2),
+                $"\"A,\",\"\"\"B\",\"C\"\"\",\"D'\"{Environment.NewLine}X,Y,Z,{Environment.NewLine}X,Y,Z,{Environment.NewLine}");
         }
 
         //[TestMethod]
@@ -47,7 +51,8 @@ namespace Csv.Tests
         [TestMethod]
         public void DontEscapeCommaForCustomSeparator()
         {
-            CheckOutput(["A", "B", "C"], Enumerable.Repeat(new[] { "X,", "Y;", "Z" }, 2), "A;B;C\r\nX,;\"Y;\";Z\r\nX,;\"Y;\";Z\r\n", ';');
+            CheckOutput(["A", "B", "C"], Enumerable.Repeat(new[] { "X,", "Y;", "Z" }, 2),
+                $"A;B;C{Environment.NewLine}X,;\"Y;\";Z{Environment.NewLine}X,;\"Y;\";Z{Environment.NewLine}", ';');
         }
 
         private static void CheckOutput(string[] headers, IEnumerable<string[]> lines, string expectedCsv, char separator = ',')


### PR DESCRIPTION
## Summary
- use `Environment.NewLine` in writer tests so assertions aren't tied to Windows line endings

## Testing
- `dotnet test`