### PR TITLE
Install .NET 9 SDK in CodeQL workflow

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -41,6 +41,11 @@ jobs:
     - run: git checkout HEAD^2
       if: ${{ github.event_name == 'pull_request' }}
 
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: '9.0.x'
+
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v3


### PR DESCRIPTION
## Summary
- setup the .NET 9 SDK so the CodeQL workflow can compile the project

## Testing
- `dotnet test --no-build` *(fails: The argument ... is invalid)*