### PR TITLE
fix: memory-based reader paths drop records after blank lines (#122)

### DIFF
--- a/Csv.Tests/EngineUnificationTests.cs
+++ b/Csv.Tests/EngineUnificationTests.cs
@@ -66,7 +66,10 @@ namespace Csv.Tests
             {
                 var byName = new Dictionary<string, string>();
                 foreach (var h in line.Headers)
-                    byName[h] = line[h];
+                {
+                    if (line.LineHasColumn(h))
+                        byName[h] = line[h];
+                }
 
                 result.Add(new Row
                 {
@@ -89,7 +92,10 @@ namespace Csv.Tests
             {
                 var byName = new Dictionary<string, string>();
                 foreach (var h in line.Headers)
-                    byName[h] = line[h];
+                {
+                    if (line.LineHasColumn(h))
+                        byName[h] = line[h];
+                }
 
                 result.Add(new Row
                 {
@@ -111,7 +117,10 @@ namespace Csv.Tests
             {
                 var byName = new Dictionary<string, string>();
                 foreach (var h in line.Headers)
-                    byName[h] = line[h];
+                {
+                    if (line.LineHasColumn(h))
+                        byName[h] = line[h];
+                }
 
                 result.Add(new Row
                 {
@@ -132,7 +141,10 @@ namespace Csv.Tests
             {
                 var byName = new Dictionary<string, string>();
                 foreach (var h in line.Headers)
-                    byName[h] = line[h];
+                {
+                    if (line.LineHasColumn(h))
+                        byName[h] = line[h];
+                }
 
                 result.Add(new Row
                 {
@@ -155,7 +167,10 @@ namespace Csv.Tests
                 var valueStrings = line.Values.Select(v => v.ToString()).ToArray();
                 var byName = new Dictionary<string, string>();
                 foreach (var h in headerStrings)
-                    byName[h] = line[h].ToString();
+                {
+                    if (line.LineHasColumn(h))
+                        byName[h] = line[h].ToString();
+                }
 
                 result.Add(new Row
                 {
@@ -606,5 +621,55 @@ namespace Csv.Tests
             System.Diagnostics.Trace.WriteLine($"ReadAsSpan over 1000 records allocated {delta} bytes.");
         }
 #endif
+
+        [TestMethod]
+        public void When_BlankLineInMiddleOfStream_Then_AllPathsContinueParsing()
+        {
+            const string csv = "a,b,c\n1,2,3\n\n4,5,6\n";
+
+            foreach (var path in AllPaths)
+            {
+                var rows = Run(path, csv, () => new CsvOptions());
+
+                Assert.AreEqual(2, rows.Count, $"{path}: expected 2 records after default SkipRow elides the blank line, got {rows.Count}");
+                Assert.AreEqual("1,2,3", rows[0].Raw, path.ToString());
+                Assert.AreEqual("4,5,6", rows[1].Raw, path.ToString());
+            }
+        }
+
+        [TestMethod]
+        public void When_BlankLineAndSkipRowDisabled_Then_AllPathsReturnEmptyRecord()
+        {
+            const string csv = "a,b,c\n1,2,3\n\n4,5,6\n";
+
+            foreach (var path in AllPaths)
+            {
+                var rows = Run(path, csv, () => new CsvOptions
+                {
+                    SkipRow = (_, _) => false,
+                    ValidateColumnCount = false,
+                    ReturnEmptyForMissingColumn = true,
+                });
+
+                Assert.AreEqual(3, rows.Count, $"{path}: expected 3 records when SkipRow is disabled (blank line surfaces as empty record), got {rows.Count}");
+                Assert.AreEqual("1,2,3", rows[0].Raw, path.ToString());
+                Assert.AreEqual(string.Empty, rows[1].Raw, path.ToString());
+                Assert.AreEqual("4,5,6", rows[2].Raw, path.ToString());
+            }
+        }
+
+        [TestMethod]
+        public void When_TrailingBlankLine_Then_AllPathsTerminateAfterLastRecord()
+        {
+            const string csv = "a,b,c\n1,2,3\n\n";
+
+            foreach (var path in AllPaths)
+            {
+                var rows = Run(path, csv, () => new CsvOptions());
+
+                Assert.AreEqual(1, rows.Count, $"{path}: expected exactly 1 record, got {rows.Count}");
+                Assert.AreEqual("1,2,3", rows[0].Raw, path.ToString());
+            }
+        }
     }
 }

--- a/Csv/CsvReader.Engine.cs
+++ b/Csv/CsvReader.Engine.cs
@@ -134,31 +134,17 @@ namespace Csv
                 {
                     line = csv.Slice(position);
                     position = csv.Length;
-                    return !line.IsEmpty;
+                    return true;
                 }
 
-                var lineLength = newlineIndex;
-                var slice = csv.Slice(position, lineLength);
+                line = csv.Slice(position, newlineIndex);
+                position += newlineIndex;
 
-                position += lineLength;
-                if (position < csv.Length)
-                {
-                    var ch = csv.Span[position];
-                    if (ch == '\r' || ch == '\n')
-                    {
-                        position++;
-                        if (position < csv.Length && ch == '\r' && csv.Span[position] == '\n')
-                            position++;
-                    }
-                }
+                var ch = csv.Span[position];
+                position++;
+                if (position < csv.Length && ch == '\r' && csv.Span[position] == '\n')
+                    position++;
 
-                if (slice.IsEmpty)
-                {
-                    line = default;
-                    return false;
-                }
-
-                line = slice;
                 return true;
             }
 
@@ -210,7 +196,7 @@ namespace Csv
                 }
 
                 line = csv.ReadLine(ref position);
-                return !line.IsEmpty;
+                return true;
             }
 
             public MemoryText Concat(MemoryText head, string newLine, MemoryText tail, out string? combined)


### PR DESCRIPTION
## Summary
- `MemorySliceLineSource.TryReadLine` and `MemoryReaderLineSource.TryReadLine` returned `false` on blank middle-of-stream lines, terminating enumeration. `Read` / `ReadAsSpan` / `ReadAsync` don't have this bug because `TextReader.ReadLine` distinguishes blank `\"\"` from EOF `null`.
- `TryReadLine` now returns `false` only when `position >= csv.Length` at entry. Blank lines surface as empty `MemoryText` with `return true`, and the engine's existing `SkipRow` logic handles them (default predicate skips empties; user-overridden predicate may surface them).
- Adds three cross-path regression tests in `Csv.Tests/EngineUnificationTests.cs`.

Resolves #122.

## Repro on master
\`\`\`csharp
var csv = \"a,b,c\r\n1,2,3\r\n\r\n4,5,6\r\n\";
foreach (var row in CsvReader.ReadFromMemoryOptimized(csv.AsMemory()))
    Console.WriteLine(row.Raw);
// Before: just \"1,2,3\"  -- the \"4,5,6\" record is silently dropped.
// After:  \"1,2,3\" then \"4,5,6\".
\`\`\`

## Pre-existing

Not a regression from #118 — this behavior was present in the pre-#118 \`ReadLineOptimized\` and \`MemoryText.ReadLine(ref position)\` extension. #118 preserved it verbatim per its consolidation scope. Gemini's review on #121 flagged it; filed as #122 because the fix requires its own correctness analysis around \`SkipRow\` semantics for blank lines.

## Test plan
- [x] \`dotnet build\` clean on netstandard2.0, net8.0, net9.0
- [x] \`dotnet test\` — 172/172 passing (excluding the pre-existing flaky \`Memory_AllocationComparison\` GC-ratio test)
- [x] \`When_BlankLineInMiddleOfStream_Then_AllPathsContinueParsing\` — all 5 paths return 2 records for \`\"a,b,c\n1,2,3\n\n4,5,6\n\"\` with default options
- [x] \`When_BlankLineAndSkipRowDisabled_Then_AllPathsReturnEmptyRecord\` — same input with \`SkipRow = (_, _) => false\` surfaces the blank line as an empty record (3 records total: \`1,2,3\` + empty + \`4,5,6\`)
- [x] \`When_TrailingBlankLine_Then_AllPathsTerminateAfterLastRecord\` — trailing blank line doesn't produce an extra record

🤖 Generated with [Claude Code](https://claude.com/claude-code)