### PR TITLE
perf: drop the pool dance from MemorySliceLineSource.Concat (#119)

### DIFF
--- a/Csv/CsvReader.Engine.cs
+++ b/Csv/CsvReader.Engine.cs
@@ -107,13 +107,11 @@ namespace Csv
         internal struct MemorySliceLineSource : ILineSource
         {
             private readonly ReadOnlyMemory<char> csv;
-            private readonly CsvMemoryOptions memoryOptions;
             private int position;
 
-            public MemorySliceLineSource(ReadOnlyMemory<char> csv, CsvMemoryOptions memoryOptions)
+            public MemorySliceLineSource(ReadOnlyMemory<char> csv)
             {
                 this.csv = csv;
-                this.memoryOptions = memoryOptions;
                 this.position = 0;
             }
 
@@ -164,27 +162,8 @@ namespace Csv
 
             public MemoryText Concat(MemoryText head, string newLine, MemoryText tail, out string? combined)
             {
-                combined = null;
-
-                var separator = newLine.AsMemory();
-                var totalLength = head.Length + separator.Length + tail.Length;
-                var buffer = memoryOptions.CharArrayPool.Rent(totalLength);
-
-                try
-                {
-                    var span = buffer.AsSpan();
-                    head.Span.CopyTo(span);
-                    separator.Span.CopyTo(span.Slice(head.Length));
-                    tail.Span.CopyTo(span.Slice(head.Length + separator.Length));
-
-                    var result = new char[totalLength];
-                    span.Slice(0, totalLength).CopyTo(result);
-                    return result.AsMemory();
-                }
-                finally
-                {
-                    memoryOptions.CharArrayPool.Return(buffer);
-                }
+                combined = string.Concat(head.Span, newLine.AsSpan(), tail.Span);
+                return combined.AsMemory();
             }
         }
 

--- a/Csv/CsvReader.cs
+++ b/Csv/CsvReader.cs
@@ -158,7 +158,7 @@ namespace Csv
         }
 
         private static IEnumerable<ICsvLineSpan> ReadFromMemoryOptimizedImpl(ReadOnlyMemory<char> csv, CsvOptions options, CsvMemoryOptions memoryOptions)
-            => Enumerate<MemorySliceLineSource, OptimizedRowFactory, ReadLineSpanOptimized>(new MemorySliceLineSource(csv, memoryOptions), new OptimizedRowFactory(memoryOptions), options);
+            => Enumerate<MemorySliceLineSource, OptimizedRowFactory, ReadLineSpanOptimized>(new MemorySliceLineSource(csv), new OptimizedRowFactory(memoryOptions), options);
 
 #endif
 


### PR DESCRIPTION
## Summary
- The pre-#118 `ConcatenateMemory` (and its post-#118 successor `MemorySliceLineSource.Concat`) rented a buffer from `CharArrayPool`, copied the three input segments in, then immediately allocated a fresh `char[]` of exact size and copied again — defeating the pool entirely and paying two allocations + three copies where one allocation suffices.
- Replace with `string.Concat(head.Span, newLine.AsSpan(), tail.Span)`. Single contiguous allocation, no pool churn, no second copy. Materialized string is captured into `out string? combined` so it's not discarded.
- Drop the now-unused `CsvMemoryOptions` field and constructor parameter on `MemorySliceLineSource`; `CsvReader.ReadFromMemoryOptimizedImpl` updated accordingly.

Resolves #119.

## Allocation profile
| Path | Before | After |
|---|---|---|
| Per multiline concat | 1 pool rent + 1 `new char[totalLength]` + 3 `CopyTo` | 1 `string.Concat` (one alloc, internal contiguous copy) |

Net: one fewer allocation, two fewer copies, no `ArrayPool` overhead, on every multiline continuation step of `ReadFromMemoryOptimized`.

## Notes
- This was deliberately preserved verbatim by #118 (approved deviation #4) to keep that PR scoped to consolidation. Fixed now per the follow-up.
- `MemoryReaderLineSource.Concat` already used `StringHelpers.Concat` (which internally calls `string.Concat`); only `MemorySliceLineSource` had the anti-pattern.
- `OptimizedRowFactory.Create` still ignores `rawString`, so the captured `combined` string isn't consumed downstream — but the cost is zero now that we've materialized it anyway.

## Test plan
- [x] `dotnet build` clean on netstandard2.0, net8.0, net9.0
- [x] `dotnet test` — 169/169 passing (excluding the pre-existing flaky `Memory_AllocationComparison` GC-ratio test)
- [x] Existing multiline tests in `Csv.Tests/EngineUnificationTests.cs` cover the `ReadFromMemoryOptimized` multiline path; they continue to pass without modification

🤖 Generated with [Claude Code](https://claude.com/claude-code)