### PR TITLE
perf: prime the row split cache from the engine's multiline loop (#120)

### DIFF
--- a/Csv/CsvReader.Engine.cs
+++ b/Csv/CsvReader.Engine.cs
@@ -35,7 +35,7 @@ namespace Csv
 
         internal interface IRowFactory<TRow> where TRow : class
         {
-            TRow Create(MemoryText[] headers, Dictionary<string, int> headerLookup, int index, MemoryText raw, string? rawString, CsvOptions options);
+            TRow Create(MemoryText[] headers, Dictionary<string, int> headerLookup, int index, MemoryText raw, string? rawString, IList<MemoryText>? rawSplit, CsvOptions options);
         }
 
         internal readonly struct TextReaderLineSource : ILineSource
@@ -188,22 +188,28 @@ namespace Csv
 
         internal readonly struct StringRowFactory : IRowFactory<ReadLine>
         {
-            public ReadLine Create(MemoryText[] headers, Dictionary<string, int> headerLookup, int index, MemoryText raw, string? rawString, CsvOptions options)
+            public ReadLine Create(MemoryText[] headers, Dictionary<string, int> headerLookup, int index, MemoryText raw, string? rawString, IList<MemoryText>? rawSplit, CsvOptions options)
             {
 #if NET8_0_OR_GREATER
-                return new ReadLine(headers, headerLookup, index, rawString ?? raw.ToString(), options);
+                var row = new ReadLine(headers, headerLookup, index, rawString ?? raw.ToString(), options);
 #else
-                return new ReadLine(headers, headerLookup, index, rawString ?? raw, options);
+                var row = new ReadLine(headers, headerLookup, index, rawString ?? raw, options);
 #endif
+                if (rawSplit != null)
+                    row.rawSplitLine = rawSplit;
+                return row;
             }
         }
 
 #if NET8_0_OR_GREATER
         internal readonly struct SpanRowFactory : IRowFactory<ReadLineSpan>
         {
-            public ReadLineSpan Create(MemoryText[] headers, Dictionary<string, int> headerLookup, int index, MemoryText raw, string? rawString, CsvOptions options)
+            public ReadLineSpan Create(MemoryText[] headers, Dictionary<string, int> headerLookup, int index, MemoryText raw, string? rawString, IList<MemoryText>? rawSplit, CsvOptions options)
             {
-                return new ReadLineSpan(headers, headerLookup, index, rawString ?? raw.ToString(), options);
+                var row = new ReadLineSpan(headers, headerLookup, index, rawString ?? raw.ToString(), options);
+                if (rawSplit != null)
+                    row.rawSplitLine = rawSplit;
+                return row;
             }
         }
 
@@ -216,17 +222,23 @@ namespace Csv
                 this.memoryOptions = memoryOptions;
             }
 
-            public ReadLineSpanOptimized Create(MemoryText[] headers, Dictionary<string, int> headerLookup, int index, MemoryText raw, string? rawString, CsvOptions options)
+            public ReadLineSpanOptimized Create(MemoryText[] headers, Dictionary<string, int> headerLookup, int index, MemoryText raw, string? rawString, IList<MemoryText>? rawSplit, CsvOptions options)
             {
-                return new ReadLineSpanOptimized(headers, headerLookup, index, raw, options, memoryOptions);
+                var row = new ReadLineSpanOptimized(headers, headerLookup, index, raw, options, memoryOptions);
+                if (rawSplit != null)
+                    row.rawSplitLine = rawSplit;
+                return row;
             }
         }
 
         internal readonly struct MemoryRowFactory : IRowFactory<ReadLineFromMemory>
         {
-            public ReadLineFromMemory Create(MemoryText[] headers, Dictionary<string, int> headerLookup, int index, MemoryText raw, string? rawString, CsvOptions options)
+            public ReadLineFromMemory Create(MemoryText[] headers, Dictionary<string, int> headerLookup, int index, MemoryText raw, string? rawString, IList<MemoryText>? rawSplit, CsvOptions options)
             {
-                return new ReadLineFromMemory(headers, headerLookup, index, raw, options);
+                var row = new ReadLineFromMemory(headers, headerLookup, index, raw, options);
+                if (rawSplit != null)
+                    row.rawSplitLine = rawSplit;
+                return row;
             }
         }
 #endif
@@ -249,6 +261,8 @@ namespace Csv
                 if (index <= options.RowsToSkip || options.SkipRow?.Invoke(line, index) == true)
                     continue;
 
+                IList<MemoryText>? rawSplit = null;
+
                 if (headers == null || headerLookup == null)
                 {
                     InitializeOptions(line.AsSpan(), options);
@@ -259,15 +273,15 @@ namespace Csv
                     // case via index == RowsToSkip + 1 and skips its own multiline pass to avoid double-reading.
                     if (!skipInitialLine && options.AllowNewLineInEnclosedFieldValues)
                     {
-                        var splitLine = options.Splitter.Split(line, options);
+                        rawSplit = options.Splitter.Split(line, options);
 
-                        while (splitLine.Count > 0 && CsvLineSplitter.IsUnterminatedQuotedValue(splitLine[splitLine.Count - 1].AsSpan(), options))
+                        while (rawSplit.Count > 0 && CsvLineSplitter.IsUnterminatedQuotedValue(rawSplit[rawSplit.Count - 1].AsSpan(), options))
                         {
                             if (!source.TryReadLine(out var nextLine, out _))
                                 break;
 
                             line = source.Concat(line, options.NewLine, nextLine, out lineString);
-                            splitLine = options.Splitter.Split(line, options);
+                            rawSplit = options.Splitter.Split(line, options);
                         }
                     }
 
@@ -314,7 +328,7 @@ namespace Csv
                 var isFirstDataLineInHeaderAbsentMode = options.HeaderMode == HeaderMode.HeaderAbsent && index == (options.RowsToSkip + 1);
                 if (options.AllowNewLineInEnclosedFieldValues && !isFirstDataLineInHeaderAbsentMode)
                 {
-                    var rawSplit = options.Splitter.Split(line, options);
+                    rawSplit = options.Splitter.Split(line, options);
                     while (rawSplit.Count > 0 && CsvLineSplitter.IsUnterminatedQuotedValue(rawSplit[rawSplit.Count - 1].AsSpan(), options))
                     {
                         if (!source.TryReadLine(out var nextLine, out _))
@@ -325,7 +339,7 @@ namespace Csv
                     }
                 }
 
-                yield return factory.Create(headers, headerLookup, index, line, lineString, options);
+                yield return factory.Create(headers, headerLookup, index, line, lineString, rawSplit, options);
             }
         }
 
@@ -352,6 +366,8 @@ namespace Csv
                 if (index <= options.RowsToSkip || options.SkipRow?.Invoke(line, index) == true)
                     continue;
 
+                IList<MemoryText>? rawSplit = null;
+
                 if (headers == null || headerLookup == null)
                 {
                     InitializeOptions(line.AsSpan(), options);
@@ -362,16 +378,16 @@ namespace Csv
                     // case via index == RowsToSkip + 1 and skips its own multiline pass to avoid double-reading.
                     if (!skipInitialLine && options.AllowNewLineInEnclosedFieldValues)
                     {
-                        var splitLine = options.Splitter.Split(line, options);
+                        rawSplit = options.Splitter.Split(line, options);
 
-                        while (splitLine.Count > 0 && CsvLineSplitter.IsUnterminatedQuotedValue(splitLine[splitLine.Count - 1].AsSpan(), options))
+                        while (rawSplit.Count > 0 && CsvLineSplitter.IsUnterminatedQuotedValue(rawSplit[rawSplit.Count - 1].AsSpan(), options))
                         {
                             var (nextOk, nextLine, _) = await source.TryReadLineAsync(ct).ConfigureAwait(false);
                             if (!nextOk)
                                 break;
 
                             line = source.Concat(line, options.NewLine, nextLine, out lineString);
-                            splitLine = options.Splitter.Split(line, options);
+                            rawSplit = options.Splitter.Split(line, options);
                         }
                     }
 
@@ -418,7 +434,7 @@ namespace Csv
                 var isFirstDataLineInHeaderAbsentMode = options.HeaderMode == HeaderMode.HeaderAbsent && index == (options.RowsToSkip + 1);
                 if (options.AllowNewLineInEnclosedFieldValues && !isFirstDataLineInHeaderAbsentMode)
                 {
-                    var rawSplit = options.Splitter.Split(line, options);
+                    rawSplit = options.Splitter.Split(line, options);
                     while (rawSplit.Count > 0 && CsvLineSplitter.IsUnterminatedQuotedValue(rawSplit[rawSplit.Count - 1].AsSpan(), options))
                     {
                         var (nextOk, nextLine, _) = await source.TryReadLineAsync(ct).ConfigureAwait(false);
@@ -430,7 +446,7 @@ namespace Csv
                     }
                 }
 
-                yield return factory.Create(headers, headerLookup, index, line, lineString, options);
+                yield return factory.Create(headers, headerLookup, index, line, lineString, rawSplit, options);
             }
         }
 #endif

--- a/Csv/CsvReader.Engine.cs
+++ b/Csv/CsvReader.Engine.cs
@@ -328,14 +328,14 @@ namespace Csv
                 var isFirstDataLineInHeaderAbsentMode = options.HeaderMode == HeaderMode.HeaderAbsent && index == (options.RowsToSkip + 1);
                 if (options.AllowNewLineInEnclosedFieldValues && !isFirstDataLineInHeaderAbsentMode)
                 {
-                    rawSplit = options.Splitter.Split(line, options);
+                    rawSplit = options.Splitter.Split(line, options, headers!.Length);
                     while (rawSplit.Count > 0 && CsvLineSplitter.IsUnterminatedQuotedValue(rawSplit[rawSplit.Count - 1].AsSpan(), options))
                     {
                         if (!source.TryReadLine(out var nextLine, out _))
                             break;
 
                         line = source.Concat(line, options.NewLine, nextLine, out lineString);
-                        rawSplit = options.Splitter.Split(line, options);
+                        rawSplit = options.Splitter.Split(line, options, headers!.Length);
                     }
                 }
 
@@ -434,7 +434,7 @@ namespace Csv
                 var isFirstDataLineInHeaderAbsentMode = options.HeaderMode == HeaderMode.HeaderAbsent && index == (options.RowsToSkip + 1);
                 if (options.AllowNewLineInEnclosedFieldValues && !isFirstDataLineInHeaderAbsentMode)
                 {
-                    rawSplit = options.Splitter.Split(line, options);
+                    rawSplit = options.Splitter.Split(line, options, headers!.Length);
                     while (rawSplit.Count > 0 && CsvLineSplitter.IsUnterminatedQuotedValue(rawSplit[rawSplit.Count - 1].AsSpan(), options))
                     {
                         var (nextOk, nextLine, _) = await source.TryReadLineAsync(ct).ConfigureAwait(false);
@@ -442,7 +442,7 @@ namespace Csv
                             break;
 
                         line = source.Concat(line, options.NewLine, nextLine, out lineString);
-                        rawSplit = options.Splitter.Split(line, options);
+                        rawSplit = options.Splitter.Split(line, options, headers!.Length);
                     }
                 }
 

--- a/Csv/CsvReader.FromMemory.cs
+++ b/Csv/CsvReader.FromMemory.cs
@@ -23,7 +23,7 @@ namespace Csv
         {
             private readonly Dictionary<string, int> headerLookup;
             private readonly CsvOptions options;
-            private IList<MemoryText>? rawSplitLine;
+            internal IList<MemoryText>? rawSplitLine;
             private MemoryText[]? parsedLine;
 
             public ReadLineFromMemory(MemoryText[] headers, Dictionary<string, int> headerLookup, int index, MemoryText raw, CsvOptions options)

--- a/Csv/CsvReader.cs
+++ b/Csv/CsvReader.cs
@@ -450,7 +450,7 @@ namespace Csv
             private readonly Dictionary<string, int> headerLookup;
             private readonly CsvOptions options;
             private readonly MemoryText[] headers;
-            private IList<MemoryText>? rawSplitLine;
+            internal IList<MemoryText>? rawSplitLine;
             internal MemoryText[]? parsedLine;
 
             public ReadLine(MemoryText[] headers, Dictionary<string, int> headerLookup, int index, string raw, CsvOptions options)
@@ -551,7 +551,7 @@ namespace Csv
             private readonly Dictionary<string, int> headerLookup;
             private readonly CsvOptions options;
             private readonly MemoryText[] headers;
-            private IList<MemoryText>? rawSplitLine;
+            internal IList<MemoryText>? rawSplitLine;
             internal MemoryText[]? parsedLine;
 
             public ReadLineSpan(MemoryText[] headers, Dictionary<string, int> headerLookup, int index, string raw, CsvOptions options)
@@ -694,7 +694,7 @@ namespace Csv
             private readonly CsvMemoryOptions memoryOptions;
             private readonly ReadOnlyMemory<char>[] headers;
             private readonly ReadOnlyMemory<char> rawMemory;
-            private IList<ReadOnlyMemory<char>>? rawSplitLine;
+            internal IList<ReadOnlyMemory<char>>? rawSplitLine;
             private ReadOnlyMemory<char>[]? parsedLine;
 
             public ReadLineSpanOptimized(ReadOnlyMemory<char>[] headers, Dictionary<string, int> headerLookup, int index, ReadOnlyMemory<char> raw, CsvOptions options, CsvMemoryOptions memoryOptions)


### PR DESCRIPTION
## Summary
- Engine's multiline continuation loop computes `options.Splitter.Split` per iteration to check for unterminated quotes, then discards the final split. The yielded row would lazily `Split` again on first field access — one redundant `Split` per multiline-enabled row.
- Extend `IRowFactory<TRow>.Create` with an `IList<MemoryText>? rawSplit` parameter; each factory assigns it to the row's `rawSplitLine` field. Engine threads the captured split from both the header-init pre-pass and the per-row multiline branch.
- Non-multiline paths pass `null` and the row's existing lazy split path is unchanged.

Resolves #120.

## What changed
- `Csv/CsvReader.Engine.cs`: `IRowFactory<TRow>.Create` gains `IList<MemoryText>? rawSplit` parameter. All four factories prime the row's `rawSplitLine` when non-null. Both `Enumerate` and `EnumerateAsync` declare `rawSplit` at iteration scope and capture from both multiline branches.
- `Csv/CsvReader.cs`: `rawSplitLine` field on `ReadLine`, `ReadLineSpan`, `ReadLineSpanOptimized` moves from `private` to `internal` (sibling-nested factory structs don't get private access; sibling-class private access only applies to types nested within the field's owning type).
- `Csv/CsvReader.FromMemory.cs`: same for `ReadLineFromMemory`.
- The row classes themselves are already `internal sealed`; `InternalsVisibleTo(\"Csv.Tests\")` is in place from `StringHelpers.cs`. No public surface widened.

## Perf delta
| Path | Before | After |
|---|---|---|
| Multiline-enabled record, single physical line | 1 Split in engine (check) + 1 Split on consumer's first field access | 1 Split in engine, cache primed; **no resplit** |
| Multiline-enabled record, N physical lines | N+1 Splits in engine + 1 Split on consumer's first field access | N+1 Splits in engine, cache primed; **no resplit** |
| Non-multiline record | 0 engine Splits + 1 lazy Split on first field access | unchanged |

## Test plan
- [x] `dotnet build` clean on netstandard2.0, net8.0, net9.0
- [x] `dotnet test` — 169/169 passing (excluding the pre-existing flaky `Memory_AllocationComparison` GC-ratio test)
- [x] Existing multiline tests in `Csv.Tests/EngineUnificationTests.cs`, `Csv.Tests/Tests.cs`, and `Csv.Tests/IssuesTests.cs` continue to pass — they cover correctness; the perf change is unobservable without benchmarks (no dedicated regression test added)

🤖 Generated with [Claude Code](https://claude.com/claude-code)