### PR TITLE
fix: quote fields containing a carriage return in CsvWriter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- `CsvWriter` not quoting fields that contain a bare carriage return (`\r`)
+  - Per RFC 4180 a field containing CR, LF, the separator, or a quote must be quoted; `CsvWriter` only triggered on `\n`, the separator, `'`, and `"`, so a value like `a\rb` was written unquoted — mis-parsed by strict readers and split into two records when re-read
+  - `CsvBufferWriter` already included `\r`; all `CsvWriter` paths (sync, async, and the `ReadOnlyMemory<char>` paths) now match it
+
+### Performance
+- Removed a per-row `char[]` allocation in `CsvWriter.WriteLine`/`WriteLineAsync` by caching the fixed quote-trigger characters in a static array and checking the variable separator separately
+
 ## [2.0.245] - 2026-05-17
 
 ### Fixed

--- a/Csv.Tests/WriterTests.cs
+++ b/Csv.Tests/WriterTests.cs
@@ -45,6 +45,42 @@ namespace Csv.Tests
                 $"\"A,\",\"\"\"B\",\"C\"\"\",\"D'\"{Environment.NewLine}X,Y,Z,{Environment.NewLine}X,Y,Z,{Environment.NewLine}");
         }
 
+        [TestMethod]
+        public void EscapesFieldContainingCarriageReturn()
+        {
+            // RFC 4180: a lone CR must force quoting just like LF. Without it, "a\rb" would be
+            // written unquoted and mis-split by strict parsers. CsvBufferWriter already quoted CR;
+            // CsvWriter now matches it.
+            var result = CsvWriter.WriteToText(["A"], [["a\rb"]]);
+            Assert.AreEqual($"A{Environment.NewLine}\"a\rb\"{Environment.NewLine}", result);
+        }
+
+        [TestMethod]
+        public async Task EscapesFieldContainingCarriageReturn_Async()
+        {
+            var writer = new StringWriter();
+            await CsvWriter.WriteAsync(writer, ["A"], [["a\rb"]]);
+            Assert.AreEqual($"A{Environment.NewLine}\"a\rb\"{Environment.NewLine}", writer.ToString());
+        }
+
+#if NET8_0_OR_GREATER
+        [TestMethod]
+        public void EscapesFieldContainingCarriageReturn_MemoryPath()
+        {
+            var headers = new[] { "A".AsMemory() };
+            var rows = new[] { new[] { "a\rb".AsMemory() } };
+            Assert.AreEqual($"A{Environment.NewLine}\"a\rb\"{Environment.NewLine}", CsvWriter.WriteToText(headers, rows));
+        }
+
+        [TestMethod]
+        public void BufferWriterAndCsvWriterAgreeOnCarriageReturn()
+        {
+            using var buffer = new CsvBufferWriter();
+            buffer.WriteRow(new[] { "a\rb".AsMemory() });
+            StringAssert.Contains(buffer.ToString(), "\"a\rb\"");
+        }
+#endif
+
         //[TestMethod]
         //public void RowsNewLineEscapedValues()
         //{

--- a/Csv/CsvWriter.cs
+++ b/Csv/CsvWriter.cs
@@ -27,12 +27,13 @@ namespace Csv
         // Without this caching, MemoryExtensions.IndexOfAny(ReadOnlySpan, ReadOnlySpan)/char[]
         // builds a fresh SearchValues<char> on the heap every call.
         private static readonly SearchValues<char> FixedEscapeChars = SearchValues.Create("'\n\r");
-#endif
-
+#else
         // RFC 4180: a field must be quoted when it contains a quote, the separator, CR, or LF.
-        // The separator varies per call, so only the fixed triggers are cached here as a shared
-        // array (scanned alongside a separate separator check) to avoid a per-row char[] allocation.
+        // Kept as a shared array (scanned alongside a separate separator check) so WriteLine
+        // doesn't allocate a per-row char[] on the netstandard2.0 path. NET8+ uses the
+        // vectorized SearchValues above instead.
         private static readonly char[] FixedEscapeCharsArray = { '\'', '\n', '\r' };
+#endif
 
         /// <summary>
         /// Writes the lines to the writer without headers. Column count is determined from the first data line.
@@ -491,7 +492,11 @@ namespace Csv
                         escape = true;
                         cell = cell.Replace("\"", "\"\"");
                     }
+#if NET8_0_OR_GREATER
+                    else if (cell.Contains(separator) || cell.AsSpan().IndexOfAny(FixedEscapeChars) >= 0)
+#else
                     else if (cell.IndexOf(separator) >= 0 || cell.IndexOfAny(FixedEscapeCharsArray) >= 0)
+#endif
                         escape = true;
 
                     if (escape)
@@ -558,7 +563,11 @@ namespace Csv
                         // Write closing quote
                         await writer.WriteAsync('"').ConfigureAwait(false);
                     }
+#if NET8_0_OR_GREATER
+                    else if (cell.Contains(separator) || cell.AsSpan().IndexOfAny(FixedEscapeChars) >= 0)
+#else
                     else if (cell.IndexOf(separator) >= 0 || cell.IndexOfAny(FixedEscapeCharsArray) >= 0)
+#endif
                     {
                         await writer.WriteAsync('"').ConfigureAwait(false);
                         await writer.WriteAsync(cell).ConfigureAwait(false);

--- a/Csv/CsvWriter.cs
+++ b/Csv/CsvWriter.cs
@@ -26,8 +26,13 @@ namespace Csv
         // Keep the fixed escape chars cached and check the separator with a separate Contains.
         // Without this caching, MemoryExtensions.IndexOfAny(ReadOnlySpan, ReadOnlySpan)/char[]
         // builds a fresh SearchValues<char> on the heap every call.
-        private static readonly SearchValues<char> FixedEscapeChars = SearchValues.Create("'\n");
+        private static readonly SearchValues<char> FixedEscapeChars = SearchValues.Create("'\n\r");
 #endif
+
+        // RFC 4180: a field must be quoted when it contains a quote, the separator, CR, or LF.
+        // The separator varies per call, so only the fixed triggers are cached here as a shared
+        // array (scanned alongside a separate separator check) to avoid a per-row char[] allocation.
+        private static readonly char[] FixedEscapeCharsArray = { '\'', '\n', '\r' };
 
         /// <summary>
         /// Writes the lines to the writer without headers. Column count is determined from the first data line.
@@ -468,7 +473,6 @@ namespace Csv
 
         private static void WriteLine(TextWriter writer, string[] data, int columnCount, char separator)
         {
-            var escapeChars = new[] { separator, '\'', '\n' };
             for (var i = 0; i < columnCount; i++)
             {
                 if (i > 0)
@@ -487,7 +491,7 @@ namespace Csv
                         escape = true;
                         cell = cell.Replace("\"", "\"\"");
                     }
-                    else if (cell.IndexOfAny(escapeChars) >= 0)
+                    else if (cell.IndexOf(separator) >= 0 || cell.IndexOfAny(FixedEscapeCharsArray) >= 0)
                         escape = true;
 
                     if (escape)
@@ -503,7 +507,6 @@ namespace Csv
 
         private static async Task WriteLineAsync(TextWriter writer, string[] data, int columnCount, char separator)
         {
-            var escapeChars = new[] { separator, '\'', '\n' };
             for (var i = 0; i < columnCount; i++)
             {
                 if (i > 0)
@@ -555,7 +558,7 @@ namespace Csv
                         // Write closing quote
                         await writer.WriteAsync('"').ConfigureAwait(false);
                     }
-                    else if (cell.IndexOfAny(escapeChars) >= 0)
+                    else if (cell.IndexOf(separator) >= 0 || cell.IndexOfAny(FixedEscapeCharsArray) >= 0)
                     {
                         await writer.WriteAsync('"').ConfigureAwait(false);
                         await writer.WriteAsync(cell).ConfigureAwait(false);


### PR DESCRIPTION
## What

`CsvWriter` now quotes fields that contain a bare carriage return (`\r`), matching `CsvBufferWriter` and RFC 4180.

## Why

Per RFC 4180, a field must be quoted when it contains a quote, the separator, **CR**, or LF. `CsvWriter` only triggered quoting on `"`, the separator, `'`, and `\n` — it omitted `\r`. `CsvBufferWriter` already included `\r` (`SearchValues.Create("''\n\r")`), so the two writers disagreed.

Consequences of the bug:
- A value like `a\rb` was written **unquoted**, which strict RFC-4180 parsers (Excel, etc.) treat as a record break → malformed output.
- Round-tripped through this library it split into **two records** instead of one.

This was a pre-existing issue; it was surfaced by Gemini's review of #127 (the terminology PR), which made the two writers' now-identically-named trigger sets visibly disagree.

## Changes

- `CsvWriter`: add `\r` to the cached `SearchValues` (memory/buffer paths) and to the string paths (`WriteLine` / `WriteLineAsync`). All four write paths — sync string, async string, and the two `ReadOnlyMemory<char>` paths — now quote on `\r`.
- Perf: removed the per-row `char[]` allocation in `WriteLine`/`WriteLineAsync` by caching the fixed trigger chars in a static array and checking the variable separator separately (mirrors what the memory paths already do).
- Tests: regression coverage for the sync, async, and memory paths, plus an assertion that `CsvWriter` and `CsvBufferWriter` now agree on `\r`.
- CHANGELOG updated under **Unreleased**.

## Verification

- Builds on `netstandard2.0` / `net8.0` / `net9.0`, 0 errors.
- **183/183** tests pass.

> Note: the timing-based `Performance_CompareWriterMethods` micro-benchmark is pre-existing-flaky under parallel test execution (no warmup, sub-5ms measurements). It passes consistently in isolation; the allocation removal here makes the traditional baseline marginally faster, which slightly tightens its ratio check. Not touched in this PR — flagging in case you want to robustify it separately.

Follow-up to the review on #127; that PR remains terminology-only / behavior-neutral.

🤖 Generated with [Claude Code](https://claude.com/claude-code)