### PR TITLE
refactor: collapse four CsvReader row classes into one CsvLine<TPolicy> (#132)

### DIFF
--- a/Csv.Tests.NetStandard/Csv.Tests.NetStandard.csproj
+++ b/Csv.Tests.NetStandard/Csv.Tests.NetStandard.csproj
@@ -1,0 +1,42 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <!--
+    Exercises the netstandard2.0 BUILD of Csv against a real runtime.
+
+    netstandard2.0 is a compatibility surface, not a runnable framework, so this project
+    targets .NET Framework 4.8: net48 is compatible with netstandard2.0 but NOT with
+    net8.0/net9.0, so the Csv project reference resolves to the netstandard2.0 asset
+    (the same resolution the review probe relied on). This is the only place tests run
+    against the ns2.0 path - where the MemoryText type alias is `string` and the
+    ReturnEmptyForMissingColumn "" vs null contract lives. The main Csv.Tests project
+    (net9.0) covers the net8+ Span/Memory surface.
+
+    LangVersion is pinned to latest because the SDK otherwise defaults net48 to C# 7.3.
+  -->
+  <PropertyGroup>
+    <AssemblyTitle>Csv.Tests.NetStandard</AssemblyTitle>
+    <TargetFramework>net48</TargetFramework>
+    <LangVersion>latest</LangVersion>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Csv\Csv.csproj" />
+  </ItemGroup>
+
+  <!--
+    Reuse the refactor's own boundary tests instead of duplicating them. Under net48 the
+    #if NET8_0_OR_GREATER guards exclude the Span/Memory cases, leaving the string-path
+    FIX 1/2/3 tests (incl. the missing-column null trap) to run against the ns2.0 build.
+  -->
+  <ItemGroup>
+    <Compile Include="..\Csv.Tests\RowUnificationTests.cs" Link="RowUnificationTests.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
+    <PackageReference Include="MSTest.TestFramework" Version="4.2.3" />
+    <PackageReference Include="MSTest.TestAdapter" Version="4.2.3" />
+  </ItemGroup>
+
+</Project>

--- a/Csv.Tests.NetStandard/NetStandardContractTests.cs
+++ b/Csv.Tests.NetStandard/NetStandardContractTests.cs
@@ -1,0 +1,65 @@
+using System;
+using System.Linq;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Csv.Tests.NetStandard
+{
+    /// <summary>
+    /// Pins the netstandard2.0 build of Csv at runtime. The main Csv.Tests suite runs net9.0
+    /// only, so without this project the ns2.0 behavioral path - where the <c>MemoryText</c>
+    /// type alias is <c>string</c>, and a <c>default(MemoryText)</c> empty would be <c>null</c>
+    /// rather than <c>""</c> - is verified by inspection alone. These tests, together with the
+    /// linked <see cref="RowUnificationTests"/>, run against the real ns2.0 assembly.
+    /// </summary>
+    [TestClass]
+    public class NetStandardContractTests
+    {
+        [TestMethod]
+        public void LoadedCsvAssemblyIsTheNetStandardBuild()
+        {
+            // ICsvLineSpan is a net8.0+ public type. Its absence proves the resolved Csv
+            // reference is the netstandard2.0 asset, so the assertions in this project really
+            // do exercise the ns2.0 surface rather than an accidentally-loaded net8 build.
+            Assert.IsNull(typeof(CsvReader).Assembly.GetType("Csv.ICsvLineSpan"),
+                "expected the netstandard2.0 build of Csv (ICsvLineSpan is net8.0+ only)");
+        }
+
+        [TestMethod]
+        public void MissingColumnUnderReturnEmpty_IsNonNullEmptyString()
+        {
+            // The headline regression the CsvLine<TPolicy> unification had to avoid: on ns2.0
+            // MemoryText == string, so the missing-column empty must be "" and never null.
+            var options = new CsvOptions { ReturnEmptyForMissingColumn = true };
+            var line = CsvReader.ReadFromText("a,b\n1,2\n", options).Single();
+
+            string value = line["NoSuchCol"];
+
+            Assert.IsNotNull(value, "missing-column lookup must not be null on netstandard2.0");
+            Assert.AreEqual(string.Empty, value);
+        }
+
+        [TestMethod]
+        public void StrictMissingColumn_StillThrows()
+        {
+            // Without ReturnEmptyForMissingColumn the lookup must still throw, matching the
+            // net8 surface (CsvReader.Get -> ArgumentOutOfRangeException with the column name).
+            var line = CsvReader.ReadFromText("a,b\n1,2\n").Single();
+
+            Assert.ThrowsExactly<ArgumentOutOfRangeException>(() => _ = line["NoSuchCol"]);
+        }
+
+        [TestMethod]
+        public void ReadAndWriteRoundTrip_Work()
+        {
+            // Smoke test: the core string read + write paths function on the ns2.0 build.
+            var line = CsvReader.ReadFromText("name,age\nAlice,30\n").Single();
+            Assert.AreEqual("Alice", line["name"]);
+            Assert.AreEqual("30", line["age"]);
+            Assert.AreEqual("Alice,30", line.Raw);
+
+            var written = CsvWriter.WriteToText(new[] { "name", "age" }, new[] { new[] { "Bob", "40" } });
+            StringAssert.Contains(written, "name,age");
+            StringAssert.Contains(written, "Bob,40");
+        }
+    }
+}

--- a/Csv.Tests/RowUnificationTests.cs
+++ b/Csv.Tests/RowUnificationTests.cs
@@ -1,0 +1,212 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Csv.Tests
+{
+    /// <summary>
+    /// Boundary tests for the three hardening fixes that came out of unifying the four
+    /// row classes into <c>CsvReader.CsvLine&lt;TPolicy&gt;</c> (issue #132):
+    ///   FIX 1 - a missing-column lookup under <see cref="CsvOptions.ReturnEmptyForMissingColumn"/>
+    ///           returns a non-null empty value on every read path / interface surface.
+    ///   FIX 2 - <c>GetBlock</c> sub-lines keep their pre-extracted cell values instead of
+    ///           re-splitting the synthesized full <c>Raw</c>.
+    ///   FIX 3 - <c>Raw</c> / <c>RawMemory</c> round-trip the original line text, and on the
+    ///           memory paths <c>RawMemory</c> aliases the source buffer (zero-copy intent).
+    /// These run net9.0 only (the test project's TFM), so the netstandard2.0-specific notes
+    /// below document the contract the shared code must keep on that target.
+    /// </summary>
+    [TestClass]
+    public class RowUnificationTests
+    {
+        // ------------------------------------------------------------------
+        // FIX 1: empty-value policy for a missing column, on every read path.
+        // ------------------------------------------------------------------
+        //
+        // The shared accessor returns CsvLine<TPolicy>.Empty ("".AsMemory()) for a missing
+        // column when ReturnEmptyForMissingColumn is set. The risk this pins is
+        // netstandard2.0-specific: there MemoryText == string, so a `default(MemoryText)`
+        // empty would be NULL, not "". Returning an explicit "".AsMemory() keeps the value
+        // non-null on every target. These tests run on net9 only, so they assert the
+        // observable net9 contract (Length == 0 on the memory surfaces, non-null "" on the
+        // ICsvLine string surface) and document the ns2.0 intent.
+
+        private const string TwoCol = "a,b\n1,2\n";
+
+        private static CsvOptions ReturnEmptyOptions() => new CsvOptions { ReturnEmptyForMissingColumn = true };
+
+        [TestMethod]
+        public void When_MissingColumnAndReturnEmpty_Then_ReadFromTextStringIndexerReturnsNonNullEmpty()
+        {
+            var line = CsvReader.ReadFromText(TwoCol, ReturnEmptyOptions()).Single();
+
+            string value = line["NoSuchCol"];
+
+            // ICsvLine.this[string] is a reference type, so guard non-null explicitly:
+            // on ns2.0 a `default` empty MemoryText would surface here as null.
+            Assert.IsNotNull(value, "missing-column lookup must not be null");
+            Assert.AreEqual(string.Empty, value);
+        }
+
+#if NET8_0_OR_GREATER
+        [TestMethod]
+        public void When_MissingColumnAndReturnEmpty_Then_ReadFromTextAsSpanSurfacesAreEmpty()
+        {
+            var line = CsvReader.ReadFromTextAsSpan(TwoCol, ReturnEmptyOptions()).Single();
+
+            string value = line["NoSuchCol"];
+            Assert.IsNotNull(value, "missing-column lookup must not be null");
+            Assert.AreEqual(string.Empty, value);
+
+            Assert.AreEqual(0, line.GetMemory("NoSuchCol").Length);
+            Assert.AreEqual(0, line.GetSpan("NoSuchCol").Length);
+        }
+
+        [TestMethod]
+        public void When_MissingColumnAndReturnEmpty_Then_ReadFromMemoryStringIndexerIsEmpty()
+        {
+            var line = CsvReader.ReadFromMemory("a,b\n1,2".AsMemory(), ReturnEmptyOptions()).Single();
+
+            // ICsvLineFromMemory.this[string] returns ReadOnlyMemory<char>; the contract is
+            // an empty (Length == 0), non-default slice rather than a null backing string.
+            Assert.AreEqual(0, line["NoSuchCol"].Length);
+        }
+
+        [TestMethod]
+        public void When_MissingColumnAndReturnEmpty_Then_ReadFromMemoryOptimizedSurfacesAreEmpty()
+        {
+            var line = CsvReader.ReadFromMemoryOptimized(TwoCol.AsMemory(), ReturnEmptyOptions()).Single();
+
+            string value = line["NoSuchCol"];
+            Assert.IsNotNull(value, "missing-column lookup must not be null");
+            Assert.AreEqual(string.Empty, value);
+
+            Assert.AreEqual(0, line.GetMemory("NoSuchCol").Length);
+            Assert.AreEqual(0, line.GetSpan("NoSuchCol").Length);
+        }
+#endif
+
+        // ------------------------------------------------------------------
+        // FIX 2: GetBlock pre-seeded values survive (no re-split of synthesized Raw).
+        // ------------------------------------------------------------------
+        //
+        // GetBlock builds each sub-line by pre-extracting the selected cells and passing them
+        // as parsedValues, while it passes the ORIGINAL full line text as the sub-line's Raw.
+        // If parsedValues pre-seeding were dropped, the sub-line would lazily re-split its Raw
+        // (the whole original row) and surface the WRONG columns. The cases below select column
+        // subsets where a re-split of Raw would visibly disagree with the pre-seeded values, so
+        // the test fails loudly if the pre-seeding regresses.
+
+        [TestMethod]
+        public void When_GetBlockSelectsTrailingColumnSubset_Then_SubLineKeepsPreExtractedValuesNotResplitRaw()
+        {
+            // 4 columns; select only the last two (col_start = 2). A re-split of the sub-line's
+            // Raw ("w,x,y,z") would yield ["w","x"] for the first two slots, whereas the correct
+            // pre-extracted values for headers [c,d] are ["y","z"].
+            var lines = CsvReader.ReadFromText("a,b,c,d\nw,x,y,z\n").ToList();
+
+            var block = lines.GetBlock(row_start: 0, row_length: -1, col_start: 2, col_length: -1).ToList();
+
+            Assert.AreEqual(1, block.Count);
+            var sub = block[0];
+
+            CollectionAssert.AreEqual(new[] { "c", "d" }, sub.Headers);
+            CollectionAssert.AreEqual(new[] { "y", "z" }, sub.Values,
+                "sub-line must keep the pre-extracted cell values, not a re-split of the full Raw");
+            Assert.AreEqual("y", sub["c"]);
+            Assert.AreEqual("z", sub["d"]);
+            Assert.AreEqual(2, sub.ColumnCount);
+
+            // The sub-line's Raw is the original full row; re-splitting it would give 4 fields,
+            // so this confirms the values came from pre-seeding, not from splitting Raw.
+            Assert.AreEqual(4, sub.Raw.Split(',').Length);
+        }
+
+        [TestMethod]
+        public void When_GetBlockSelectsMiddleColumnSubset_Then_ValuesMatchSelectedCells()
+        {
+            // Select exactly one middle column (col_start = 1, col_length = 1). A re-split of Raw
+            // would put "w" in slot 0; the correct pre-extracted value for header [b] is "x".
+            var lines = CsvReader.ReadFromText("a,b,c,d\nw,x,y,z\n").ToList();
+
+            var block = lines.GetBlock(row_start: 0, row_length: -1, col_start: 1, col_length: 1).ToList();
+
+            Assert.AreEqual(1, block.Count);
+            var sub = block[0];
+
+            CollectionAssert.AreEqual(new[] { "b" }, sub.Headers);
+            CollectionAssert.AreEqual(new[] { "x" }, sub.Values);
+            Assert.AreEqual("x", sub["b"]);
+            Assert.AreEqual(1, sub.ColumnCount);
+        }
+
+        // ------------------------------------------------------------------
+        // FIX 3: Raw identity / zero-copy intent.
+        // ------------------------------------------------------------------
+
+        [TestMethod]
+        public void When_ReadFromText_Then_RawIsTheOriginalLineText()
+        {
+            var lines = CsvReader.ReadFromText("a,b\n1,2\n3,4\n").ToList();
+
+            Assert.AreEqual(2, lines.Count);
+            Assert.AreEqual("1,2", lines[0].Raw);
+            Assert.AreEqual("3,4", lines[1].Raw);
+        }
+
+#if NET8_0_OR_GREATER
+        [TestMethod]
+        public void When_ReadFromTextAsSpan_Then_RawAndRawMemoryRoundTripTheLineText()
+        {
+            var lines = CsvReader.ReadFromTextAsSpan("a,b\n1,2\n3,4\n").ToList();
+
+            Assert.AreEqual(2, lines.Count);
+
+            // Raw (string) and RawMemory (ReadOnlyMemory<char>) describe the same line text.
+            Assert.AreEqual("1,2", lines[0].Raw);
+            Assert.AreEqual("1,2", lines[0].RawMemory.ToString());
+            Assert.AreEqual("3,4", lines[1].Raw);
+            Assert.AreEqual("3,4", lines[1].RawMemory.ToString());
+        }
+
+        [TestMethod]
+        public void When_ReadFromMemoryOptimized_Then_RawMemoryAliasesTheSourceBufferZeroCopy()
+        {
+            // The memory paths slice the source memory rather than copying, so a row's RawMemory
+            // must point INTO the original backing string. This expresses the zero-alloc intent
+            // of FIX 3 the testable way (reference identity), avoiding a brittle byte-count assert.
+            var source = "a,b\n1,2\n3,4\n";
+            var lines = CsvReader.ReadFromMemoryOptimized(source.AsMemory()).ToList();
+
+            Assert.AreEqual(2, lines.Count);
+            Assert.AreEqual("1,2", lines[0].RawMemory.ToString());
+            Assert.AreEqual("3,4", lines[1].RawMemory.ToString());
+
+            // MemoryMarshal.TryGetString recovers the backing string of a string-derived slice.
+            // Identical (reference-equal) backing string proves RawMemory is a view, not a copy.
+            Assert.IsTrue(MemoryMarshal.TryGetString(lines[0].RawMemory, out var backing, out _, out _),
+                "RawMemory should be backed by a string on the memory path");
+            Assert.AreSame(source, backing,
+                "RawMemory must alias the source buffer rather than allocate a copy");
+        }
+
+        [TestMethod]
+        public void When_ReadFromMemory_Then_RawIsTheOriginalLineTextAndAliasesSource()
+        {
+            var source = "a,b\n1,2\n3,4\n";
+            var lines = CsvReader.ReadFromMemory(source.AsMemory()).ToList();
+
+            Assert.AreEqual(2, lines.Count);
+            Assert.AreEqual("1,2", lines[0].Raw.ToString());
+            Assert.AreEqual("3,4", lines[1].Raw.ToString());
+
+            Assert.IsTrue(MemoryMarshal.TryGetString(lines[0].Raw, out var backing, out _, out _),
+                "Raw should be backed by a string on the memory path");
+            Assert.AreSame(source, backing,
+                "Raw must alias the source buffer rather than allocate a copy");
+        }
+#endif
+    }
+}

--- a/Csv.sln
+++ b/Csv.sln
@@ -1,4 +1,4 @@
-
+﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
 VisualStudioVersion = 15.0.26730.3
@@ -12,20 +12,54 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		README.md = README.md
 	EndProjectSection
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Csv.Tests.NetStandard", "Csv.Tests.NetStandard\Csv.Tests.NetStandard.csproj", "{3A9851B1-6B21-4033-B9AC-9A571507DFB4}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
 		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{C47AD6DF-3CE4-4105-A9A5-C3FE02FAAE06}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{C47AD6DF-3CE4-4105-A9A5-C3FE02FAAE06}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C47AD6DF-3CE4-4105-A9A5-C3FE02FAAE06}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{C47AD6DF-3CE4-4105-A9A5-C3FE02FAAE06}.Debug|x64.Build.0 = Debug|Any CPU
+		{C47AD6DF-3CE4-4105-A9A5-C3FE02FAAE06}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{C47AD6DF-3CE4-4105-A9A5-C3FE02FAAE06}.Debug|x86.Build.0 = Debug|Any CPU
 		{C47AD6DF-3CE4-4105-A9A5-C3FE02FAAE06}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{C47AD6DF-3CE4-4105-A9A5-C3FE02FAAE06}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C47AD6DF-3CE4-4105-A9A5-C3FE02FAAE06}.Release|x64.ActiveCfg = Release|Any CPU
+		{C47AD6DF-3CE4-4105-A9A5-C3FE02FAAE06}.Release|x64.Build.0 = Release|Any CPU
+		{C47AD6DF-3CE4-4105-A9A5-C3FE02FAAE06}.Release|x86.ActiveCfg = Release|Any CPU
+		{C47AD6DF-3CE4-4105-A9A5-C3FE02FAAE06}.Release|x86.Build.0 = Release|Any CPU
 		{F61D68F1-85FC-4CA7-9FB8-EC2F6A158213}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{F61D68F1-85FC-4CA7-9FB8-EC2F6A158213}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F61D68F1-85FC-4CA7-9FB8-EC2F6A158213}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{F61D68F1-85FC-4CA7-9FB8-EC2F6A158213}.Debug|x64.Build.0 = Debug|Any CPU
+		{F61D68F1-85FC-4CA7-9FB8-EC2F6A158213}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{F61D68F1-85FC-4CA7-9FB8-EC2F6A158213}.Debug|x86.Build.0 = Debug|Any CPU
 		{F61D68F1-85FC-4CA7-9FB8-EC2F6A158213}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{F61D68F1-85FC-4CA7-9FB8-EC2F6A158213}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F61D68F1-85FC-4CA7-9FB8-EC2F6A158213}.Release|x64.ActiveCfg = Release|Any CPU
+		{F61D68F1-85FC-4CA7-9FB8-EC2F6A158213}.Release|x64.Build.0 = Release|Any CPU
+		{F61D68F1-85FC-4CA7-9FB8-EC2F6A158213}.Release|x86.ActiveCfg = Release|Any CPU
+		{F61D68F1-85FC-4CA7-9FB8-EC2F6A158213}.Release|x86.Build.0 = Release|Any CPU
+		{3A9851B1-6B21-4033-B9AC-9A571507DFB4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3A9851B1-6B21-4033-B9AC-9A571507DFB4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3A9851B1-6B21-4033-B9AC-9A571507DFB4}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{3A9851B1-6B21-4033-B9AC-9A571507DFB4}.Debug|x64.Build.0 = Debug|Any CPU
+		{3A9851B1-6B21-4033-B9AC-9A571507DFB4}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{3A9851B1-6B21-4033-B9AC-9A571507DFB4}.Debug|x86.Build.0 = Debug|Any CPU
+		{3A9851B1-6B21-4033-B9AC-9A571507DFB4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3A9851B1-6B21-4033-B9AC-9A571507DFB4}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3A9851B1-6B21-4033-B9AC-9A571507DFB4}.Release|x64.ActiveCfg = Release|Any CPU
+		{3A9851B1-6B21-4033-B9AC-9A571507DFB4}.Release|x64.Build.0 = Release|Any CPU
+		{3A9851B1-6B21-4033-B9AC-9A571507DFB4}.Release|x86.ActiveCfg = Release|Any CPU
+		{3A9851B1-6B21-4033-B9AC-9A571507DFB4}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Csv/CsvReader.Engine.cs
+++ b/Csv/CsvReader.Engine.cs
@@ -186,15 +186,11 @@ namespace Csv
         }
 #endif
 
-        internal readonly struct StringRowFactory : IRowFactory<ReadLine>
+        internal readonly struct StringRowFactory : IRowFactory<CsvLine<DefaultTrimSplit>>
         {
-            public ReadLine Create(MemoryText[] headers, Dictionary<string, int> headerLookup, int index, MemoryText raw, string? rawString, IList<MemoryText>? rawSplit, CsvOptions options)
+            public CsvLine<DefaultTrimSplit> Create(MemoryText[] headers, Dictionary<string, int> headerLookup, int index, MemoryText raw, string? rawString, IList<MemoryText>? rawSplit, CsvOptions options)
             {
-#if NET8_0_OR_GREATER
-                var row = new ReadLine(headers, headerLookup, index, rawString ?? raw.ToString(), options);
-#else
-                var row = new ReadLine(headers, headerLookup, index, rawString ?? raw, options);
-#endif
+                var row = new CsvLine<DefaultTrimSplit>(headers, headerLookup, index, raw, rawString, options);
                 if (rawSplit != null)
                     row.rawFields = rawSplit;
                 return row;
@@ -202,18 +198,18 @@ namespace Csv
         }
 
 #if NET8_0_OR_GREATER
-        internal readonly struct SpanRowFactory : IRowFactory<ReadLineSpan>
+        internal readonly struct SpanRowFactory : IRowFactory<CsvLine<DefaultTrimSplit>>
         {
-            public ReadLineSpan Create(MemoryText[] headers, Dictionary<string, int> headerLookup, int index, MemoryText raw, string? rawString, IList<MemoryText>? rawSplit, CsvOptions options)
+            public CsvLine<DefaultTrimSplit> Create(MemoryText[] headers, Dictionary<string, int> headerLookup, int index, MemoryText raw, string? rawString, IList<MemoryText>? rawSplit, CsvOptions options)
             {
-                var row = new ReadLineSpan(headers, headerLookup, index, rawString ?? raw.ToString(), options);
+                var row = new CsvLine<DefaultTrimSplit>(headers, headerLookup, index, raw, rawString, options);
                 if (rawSplit != null)
                     row.rawFields = rawSplit;
                 return row;
             }
         }
 
-        internal readonly struct OptimizedRowFactory : IRowFactory<ReadLineSpanOptimized>
+        internal readonly struct OptimizedRowFactory : IRowFactory<CsvLine<OptimizedTrimSplit>>
         {
             private readonly CsvMemoryOptions memoryOptions;
 
@@ -222,20 +218,20 @@ namespace Csv
                 this.memoryOptions = memoryOptions;
             }
 
-            public ReadLineSpanOptimized Create(MemoryText[] headers, Dictionary<string, int> headerLookup, int index, MemoryText raw, string? rawString, IList<MemoryText>? rawSplit, CsvOptions options)
+            public CsvLine<OptimizedTrimSplit> Create(MemoryText[] headers, Dictionary<string, int> headerLookup, int index, MemoryText raw, string? rawString, IList<MemoryText>? rawSplit, CsvOptions options)
             {
-                var row = new ReadLineSpanOptimized(headers, headerLookup, index, raw, options, memoryOptions);
+                var row = new CsvLine<OptimizedTrimSplit>(headers, headerLookup, index, raw, rawString, options, new OptimizedTrimSplit(memoryOptions));
                 if (rawSplit != null)
                     row.rawFields = rawSplit;
                 return row;
             }
         }
 
-        internal readonly struct MemoryRowFactory : IRowFactory<ReadLineFromMemory>
+        internal readonly struct MemoryRowFactory : IRowFactory<CsvLine<DefaultTrimSplit>>
         {
-            public ReadLineFromMemory Create(MemoryText[] headers, Dictionary<string, int> headerLookup, int index, MemoryText raw, string? rawString, IList<MemoryText>? rawSplit, CsvOptions options)
+            public CsvLine<DefaultTrimSplit> Create(MemoryText[] headers, Dictionary<string, int> headerLookup, int index, MemoryText raw, string? rawString, IList<MemoryText>? rawSplit, CsvOptions options)
             {
-                var row = new ReadLineFromMemory(headers, headerLookup, index, raw, options);
+                var row = new CsvLine<DefaultTrimSplit>(headers, headerLookup, index, raw, rawString, options);
                 if (rawSplit != null)
                     row.rawFields = rawSplit;
                 return row;

--- a/Csv/CsvReader.FromMemory.cs
+++ b/Csv/CsvReader.FromMemory.cs
@@ -1,8 +1,6 @@
 ﻿#if NET8_0_OR_GREATER
 
-using System;
 using System.Collections.Generic;
-using System.Linq;
 
 using MemoryText = System.ReadOnlyMemory<char>;
 using SpanText = System.ReadOnlySpan<char>;
@@ -17,94 +15,7 @@ namespace Csv
         /// <param name="csv">The csv string to read the data from.</param>
         /// <param name="options">The optional options to use when reading.</param>
         public static IEnumerable<ICsvLineFromMemory> ReadFromMemory(MemoryText csv, CsvOptions? options = null)
-            => Enumerate<MemoryReaderLineSource, MemoryRowFactory, ReadLineFromMemory>(new MemoryReaderLineSource(csv), default, options ?? new CsvOptions());
-
-        internal sealed class ReadLineFromMemory : ICsvLineFromMemory
-        {
-            private readonly Dictionary<string, int> headerLookup;
-            private readonly CsvOptions options;
-            internal IList<MemoryText>? rawFields;
-            private MemoryText[]? parsedValues;
-
-            public ReadLineFromMemory(MemoryText[] headers, Dictionary<string, int> headerLookup, int index, MemoryText raw, CsvOptions options)
-            {
-                this.headerLookup = headerLookup;
-                this.options = options;
-                Headers = headers;
-                Raw = raw;
-                Index = index;
-            }
-
-            public MemoryText[] Headers { get; }
-
-            public MemoryText Raw { get; }
-
-            public int Index { get; }
-
-            public int ColumnCount => ParsedValues.Length;
-
-            public bool HasColumn(string name) => headerLookup.ContainsKey(name);
-
-            public bool LineHasColumn(string name)
-            {
-                if (!headerLookup.TryGetValue(name, out var index))
-                    return false;
-
-                return RawFields.Count > index;
-            }
-
-            internal IList<MemoryText> RawFields => rawFields ??= SplitLine(Raw, options);
-
-            public MemoryText[] Values => ParsedValues;
-
-            private MemoryText[] ParsedValues
-            {
-                get
-                {
-                    if (parsedValues == null)
-                    {
-                        var raw = RawFields;
-
-                        if (options.ValidateColumnCount && raw.Count != Headers.Length)
-                            throw new InvalidOperationException($"Expected {Headers.Length}, got {raw.Count} columns.");
-
-                        parsedValues = Trim(raw, options);
-                    }
-
-                    return parsedValues;
-                }
-            }
-
-            MemoryText ICsvLineFromMemory.this[string name]
-            {
-                get
-                {
-                    if (!headerLookup.TryGetValue(name, out var index))
-                    {
-                        if (options.ReturnEmptyForMissingColumn)
-                            return MemoryText.Empty;
-
-                        throw new ArgumentOutOfRangeException(nameof(name), name, $"Header '{name}' does not exist. Expected one of {string.Join("; ", Headers)}");
-                    }
-
-                    try
-                    {
-                        return ParsedValues[index];
-                    }
-                    catch (IndexOutOfRangeException)
-                    {
-                        throw new InvalidOperationException($"Invalid row, missing {name} header, expected {Headers.Length} columns, got {ParsedValues.Length} columns.");
-                    }
-                }
-            }
-
-            MemoryText ICsvLineFromMemory.this[int index] => ParsedValues[index];
-
-            public override string ToString()
-            {
-                return Raw.AsString();
-            }
-        }
+            => Enumerate<MemoryReaderLineSource, MemoryRowFactory, CsvLine<DefaultTrimSplit>>(new MemoryReaderLineSource(csv), default, options ?? new CsvOptions());
     }
 }
 

--- a/Csv/CsvReader.cs
+++ b/Csv/CsvReader.cs
@@ -117,7 +117,7 @@ namespace Csv
         }
 
         private static IEnumerable<ICsvLineSpan> ReadSpanImpl(TextReader reader, CsvOptions? options)
-            => Enumerate<TextReaderLineSource, SpanRowFactory, ReadLineSpan>(new TextReaderLineSource(reader), default, options ?? new CsvOptions());
+            => Enumerate<TextReaderLineSource, SpanRowFactory, CsvLine<DefaultTrimSplit>>(new TextReaderLineSource(reader), default, options ?? new CsvOptions());
 
         /// <summary>
         /// Reads CSV data from memory with enhanced memory management options.
@@ -158,7 +158,7 @@ namespace Csv
         }
 
         private static IEnumerable<ICsvLineSpan> ReadFromMemoryOptimizedImpl(ReadOnlyMemory<char> csv, CsvOptions options, CsvMemoryOptions memoryOptions)
-            => Enumerate<MemorySliceLineSource, OptimizedRowFactory, ReadLineSpanOptimized>(new MemorySliceLineSource(csv), new OptimizedRowFactory(memoryOptions), options);
+            => Enumerate<MemorySliceLineSource, OptimizedRowFactory, CsvLine<OptimizedTrimSplit>>(new MemorySliceLineSource(csv), new OptimizedRowFactory(memoryOptions), options);
 
 #endif
 
@@ -181,7 +181,7 @@ namespace Csv
         }
 
         private static IEnumerable<ICsvLine> ReadImpl(TextReader reader, CsvOptions? options)
-            => Enumerate<TextReaderLineSource, StringRowFactory, ReadLine>(new TextReaderLineSource(reader), default, options ?? new CsvOptions());
+            => Enumerate<TextReaderLineSource, StringRowFactory, CsvLine<DefaultTrimSplit>>(new TextReaderLineSource(reader), default, options ?? new CsvOptions());
 
 #if NET8_0_OR_GREATER
         /// <summary>
@@ -238,7 +238,7 @@ namespace Csv
         }
 
         private static IAsyncEnumerable<ICsvLine> ReadImplAsync(TextReader reader, CsvOptions? options)
-            => EnumerateAsync<AsyncTextReaderLineSource, StringRowFactory, ReadLine>(new AsyncTextReaderLineSource(reader), default, options ?? new CsvOptions());
+            => EnumerateAsync<AsyncTextReaderLineSource, StringRowFactory, CsvLine<DefaultTrimSplit>>(new AsyncTextReaderLineSource(reader), default, options ?? new CsvOptions());
 #endif
 
         private static char AutoDetectSeparator(SpanText sampleLine)
@@ -442,58 +442,85 @@ namespace Csv
                     headers = line.Headers.Skip(start).Take(length).Select(x=>x.AsMemory()).ToArray();
                 MemoryText[] values = headers.Select(x => line[x.ToString()].AsMemory()).ToArray();
                 Dictionary<string, int> map = Enumerable.Range(0, headers.Length).ToDictionary(x => headers[x].ToString());
-                return new ReadLine(headers, map, line.Index, line.Raw, new CsvOptions()) { parsedValues = values };
+#if NET8_0_OR_GREATER
+                return new CsvLine<DefaultTrimSplit>(headers, map, line.Index, line.Raw.AsMemory(), line.Raw, new CsvOptions()) { parsedValues = values };
+#else
+                return new CsvLine<DefaultTrimSplit>(headers, map, line.Index, line.Raw, line.Raw, new CsvOptions()) { parsedValues = values };
+#endif
             }
         }
-        internal sealed class ReadLine : ICsvLine
+        internal interface ITrimSplit
+        {
+            IList<MemoryText> Split(MemoryText raw, CsvOptions options, int? capacity);
+            MemoryText[] Trim(IList<MemoryText> fields, CsvOptions options);
+        }
+
+        internal readonly struct DefaultTrimSplit : ITrimSplit
+        {
+            public IList<MemoryText> Split(MemoryText raw, CsvOptions o, int? cap) => SplitLine(raw, o, cap);
+            public MemoryText[] Trim(IList<MemoryText> f, CsvOptions o) => CsvReader.Trim(f, o);
+        }
+
+#if NET8_0_OR_GREATER
+        internal readonly struct OptimizedTrimSplit : ITrimSplit
+        {
+            private readonly CsvMemoryOptions mem;
+            public OptimizedTrimSplit(CsvMemoryOptions mem) => this.mem = mem;
+            public IList<MemoryText> Split(MemoryText raw, CsvOptions o, int? cap) => SplitLineOptimized(raw, o, mem, cap);
+            public MemoryText[] Trim(IList<MemoryText> f, CsvOptions o) => TrimOptimized(f, o, mem);
+        }
+#endif
+
+        // One row type backs every read path. On net8 it implements all three frozen interfaces at once;
+        // Headers/Values/Raw/this[] collide only by return type (string vs ReadOnlyMemory<char>), so the
+        // memory-typed faces below are explicit interface implementations. Backing store is always MemoryText.
+        internal sealed class CsvLine<TPolicy> :
+                ICsvLine
+#if NET8_0_OR_GREATER
+                , ICsvLineSpan, ICsvLineFromMemory
+#endif
+            where TPolicy : struct, ITrimSplit
         {
             private readonly Dictionary<string, int> headerLookup;
             private readonly CsvOptions options;
+            private readonly TPolicy policy;
             private readonly MemoryText[] headers;
+            private readonly MemoryText rawMemory;
+            private readonly string? rawString;
             internal IList<MemoryText>? rawFields;
             internal MemoryText[]? parsedValues;
 
-            public ReadLine(MemoryText[] headers, Dictionary<string, int> headerLookup, int index, string raw, CsvOptions options)
+            private static readonly MemoryText Empty = "".AsMemory();
+
+            internal CsvLine(MemoryText[] headers, Dictionary<string, int> headerLookup, int index,
+                             MemoryText rawMemory, string? rawString, CsvOptions options, TPolicy policy = default)
             {
                 this.headerLookup = headerLookup;
                 this.options = options;
+                this.policy = policy;
                 this.headers = headers;
-                Raw = raw;
+                this.rawMemory = rawMemory;
+                this.rawString = rawString;
                 Index = index;
             }
 
-            public string[] Headers => headers.Select(it => it.AsString()).ToArray();
-
-            public string Raw { get; }
-
             public int Index { get; }
+
+            public string Raw => rawString ?? rawMemory.ToString();
 
             public int ColumnCount => ParsedValues.Length;
 
             public bool HasColumn(string name) => headerLookup.ContainsKey(name);
 
             public bool LineHasColumn(string name)
-            {
-                if (!headerLookup.TryGetValue(name, out var index))
-                    return false;
+                => headerLookup.TryGetValue(name, out var i) && RawFields.Count > i;
 
-                return RawFields.Count > index;
-            }
+            public string[] Headers => headers.Select(h => h.AsString()).ToArray();
 
-            internal IList<MemoryText> RawFields
-            {
-                get
-                {
-#if NET8_0_OR_GREATER
-                    rawFields ??= SplitLine(Raw.AsMemory(), options, headers.Length);
-#else
-                    rawFields ??= SplitLine(Raw, options, headers.Length);
-#endif
-                    return rawFields;
-                }
-            }
+            public string[] Values => ParsedValues.Select(v => v.AsString()).ToArray();
 
-            public string[] Values => ParsedValues.Select(it => it.AsString()).ToArray();
+            // headers.Length is a results-neutral presize hint for the field list; the split is identical without it.
+            internal IList<MemoryText> RawFields => rawFields ??= policy.Split(rawMemory, options, headers.Length);
 
             private MemoryText[] ParsedValues
             {
@@ -503,333 +530,114 @@ namespace Csv
                     {
                         var raw = RawFields;
 
-                        if (options.ValidateColumnCount && raw.Count != Headers.Length)
-                            throw new InvalidOperationException($"Expected {Headers.Length}, got {raw.Count} columns.");
+                        if (options.ValidateColumnCount && raw.Count != headers.Length)
+                            throw new InvalidOperationException($"Expected {headers.Length}, got {raw.Count} columns.");
 
-                        parsedValues = Trim(raw, options);
+                        parsedValues = policy.Trim(raw, options);
                     }
 
                     return parsedValues;
                 }
             }
 
-            string ICsvLine.this[string name]
+            private MemoryText Get(string name)
             {
-                get
+                if (!headerLookup.TryGetValue(name, out var i))
                 {
-                    if (!headerLookup.TryGetValue(name, out var index))
-                    {
-                        if (options.ReturnEmptyForMissingColumn)
-                            return string.Empty;
+                    if (options.ReturnEmptyForMissingColumn)
+                        return Empty;
 
-                        throw new ArgumentOutOfRangeException(nameof(name), name, $"Header '{name}' does not exist. Expected one of {string.Join("; ", Headers)}");
-                    }
+                    throw new ArgumentOutOfRangeException(nameof(name), name,
+                        $"Header '{name}' does not exist. Expected one of {string.Join("; ", headers.Select(h => h.AsString()))}");
+                }
 
-                    try
-                    {
-                        return ParsedValues[index].AsString();
-                    }
-                    catch (IndexOutOfRangeException)
-                    {
-                        throw new InvalidOperationException($"Invalid row, missing {name} header, expected {Headers.Length} columns, got {ParsedValues.Length} columns.");
-                    }
+                try
+                {
+                    return ParsedValues[i];
+                }
+                catch (IndexOutOfRangeException)
+                {
+                    throw new InvalidOperationException(
+                        $"Invalid row, missing {name} header, expected {headers.Length} columns, got {ParsedValues.Length} columns.");
                 }
             }
 
+            string ICsvLine.this[string name] => Get(name).AsString();
             string ICsvLine.this[int index] => ParsedValues[index].AsString();
 
-            public override string ToString()
+            public override string ToString() => Raw;
+
+#if NET8_0_OR_GREATER
+            public ReadOnlyMemory<char>[] HeadersMemory => headers;
+            public ReadOnlyMemory<char>[] ValuesMemory => ParsedValues;
+            public ReadOnlyMemory<char> RawMemory => rawMemory;
+            public ReadOnlySpan<char> RawSpan => rawMemory.Span;
+            public ReadOnlySpan<char> HeadersSpan => throw new NotSupportedException("HeadersSpan not supported for array access. Use GetSpan(int) or GetMemory(int) for individual headers.");
+            public ReadOnlySpan<char> ValuesSpan => throw new NotSupportedException("ValuesSpan not supported for array access. Use GetSpan(int) or GetMemory(int) for individual values.");
+
+            public ReadOnlyMemory<char> GetMemory(string name) => Get(name);
+            public ReadOnlyMemory<char> GetMemory(int index) => ParsedValues[index];
+
+            public ReadOnlySpan<char> GetSpan(string name) => GetMemory(name).Span;
+            public ReadOnlySpan<char> GetSpan(int index) => GetMemory(index).Span;
+
+            public bool TryGetMemory(string name, out ReadOnlyMemory<char> value)
             {
-                return Raw;
+                if (headerLookup.TryGetValue(name, out var index) && index < ParsedValues.Length)
+                {
+                    value = ParsedValues[index];
+                    return true;
+                }
+
+                value = ReadOnlyMemory<char>.Empty;
+                return false;
             }
+
+            public bool TryGetMemory(int index, out ReadOnlyMemory<char> value)
+            {
+                if (index >= 0 && index < ParsedValues.Length)
+                {
+                    value = ParsedValues[index];
+                    return true;
+                }
+
+                value = ReadOnlyMemory<char>.Empty;
+                return false;
+            }
+
+            public bool TryGetSpan(string name, out ReadOnlySpan<char> value)
+            {
+                if (TryGetMemory(name, out var memory))
+                {
+                    value = memory.Span;
+                    return true;
+                }
+
+                value = ReadOnlySpan<char>.Empty;
+                return false;
+            }
+
+            public bool TryGetSpan(int index, out ReadOnlySpan<char> value)
+            {
+                if (TryGetMemory(index, out var memory))
+                {
+                    value = memory.Span;
+                    return true;
+                }
+
+                value = ReadOnlySpan<char>.Empty;
+                return false;
+            }
+
+            MemoryText[] ICsvLineFromMemory.Headers => headers;
+            MemoryText[] ICsvLineFromMemory.Values => ParsedValues;
+            MemoryText ICsvLineFromMemory.Raw => rawMemory;
+            MemoryText ICsvLineFromMemory.this[string name] => Get(name);
+            MemoryText ICsvLineFromMemory.this[int index] => ParsedValues[index];
+#endif
         }
 
 #if NET8_0_OR_GREATER
-
-        internal sealed class ReadLineSpan : ICsvLineSpan
-        {
-            private readonly Dictionary<string, int> headerLookup;
-            private readonly CsvOptions options;
-            private readonly MemoryText[] headers;
-            internal IList<MemoryText>? rawFields;
-            internal MemoryText[]? parsedValues;
-
-            public ReadLineSpan(MemoryText[] headers, Dictionary<string, int> headerLookup, int index, string raw, CsvOptions options)
-            {
-                this.headerLookup = headerLookup;
-                this.options = options;
-                this.headers = headers;
-                Raw = raw;
-                Index = index;
-            }
-
-            public string[] Headers => headers.Select(it => it.AsString()).ToArray();
-            public ReadOnlyMemory<char>[] HeadersMemory => headers;
-            public ReadOnlySpan<char> HeadersSpan => throw new NotSupportedException("HeadersSpan not supported for array access. Use GetSpan(int) or GetMemory(int) for individual headers.");
-
-            public string Raw { get; }
-            public ReadOnlyMemory<char> RawMemory => Raw.AsMemory();
-            public ReadOnlySpan<char> RawSpan => Raw.AsSpan();
-
-            public int Index { get; }
-            public int ColumnCount => ParsedValues.Length;
-
-            public bool HasColumn(string name) => headerLookup.ContainsKey(name);
-
-            public bool LineHasColumn(string name)
-            {
-                if (!headerLookup.TryGetValue(name, out var index))
-                    return false;
-
-                return RawFields.Count > index;
-            }
-
-            internal IList<MemoryText> RawFields => rawFields ??= SplitLine(Raw.AsMemory(), options, headers.Length);
-
-            public string[] Values => ParsedValues.Select(it => it.AsString()).ToArray();
-            public ReadOnlyMemory<char>[] ValuesMemory => ParsedValues;
-            public ReadOnlySpan<char> ValuesSpan => throw new NotSupportedException("ValuesSpan not supported for array access. Use GetSpan(int) or GetMemory(int) for individual values.");
-
-            private MemoryText[] ParsedValues
-            {
-                get
-                {
-                    if (parsedValues == null)
-                    {
-                        var raw = RawFields;
-
-                        if (options.ValidateColumnCount && raw.Count != Headers.Length)
-                            throw new InvalidOperationException($"Expected {Headers.Length}, got {raw.Count} columns.");
-
-                        parsedValues = Trim(raw, options);
-                    }
-
-                    return parsedValues;
-                }
-            }
-
-            string ICsvLine.this[string name] => GetSpan(name).ToString();
-            string ICsvLine.this[int index] => GetSpan(index).ToString();
-
-            public ReadOnlyMemory<char> GetMemory(string name)
-            {
-                if (!headerLookup.TryGetValue(name, out var index))
-                {
-                    if (options.ReturnEmptyForMissingColumn)
-                        return ReadOnlyMemory<char>.Empty;
-
-                    throw new ArgumentOutOfRangeException(nameof(name), name, $"Header '{name}' does not exist. Expected one of {string.Join("; ", Headers)}");
-                }
-
-                try
-                {
-                    return ParsedValues[index];
-                }
-                catch (IndexOutOfRangeException)
-                {
-                    throw new InvalidOperationException($"Invalid row, missing {name} header, expected {Headers.Length} columns, got {ParsedValues.Length} columns.");
-                }
-            }
-
-            public ReadOnlyMemory<char> GetMemory(int index) => ParsedValues[index];
-
-            public ReadOnlySpan<char> GetSpan(string name) => GetMemory(name).Span;
-            public ReadOnlySpan<char> GetSpan(int index) => GetMemory(index).Span;
-
-            public bool TryGetMemory(string name, out ReadOnlyMemory<char> value)
-            {
-                if (headerLookup.TryGetValue(name, out var index) && index < ParsedValues.Length)
-                {
-                    value = ParsedValues[index];
-                    return true;
-                }
-
-                value = ReadOnlyMemory<char>.Empty;
-                return false;
-            }
-
-            public bool TryGetMemory(int index, out ReadOnlyMemory<char> value)
-            {
-                if (index >= 0 && index < ParsedValues.Length)
-                {
-                    value = ParsedValues[index];
-                    return true;
-                }
-
-                value = ReadOnlyMemory<char>.Empty;
-                return false;
-            }
-
-            public bool TryGetSpan(string name, out ReadOnlySpan<char> value)
-            {
-                if (TryGetMemory(name, out var memory))
-                {
-                    value = memory.Span;
-                    return true;
-                }
-
-                value = ReadOnlySpan<char>.Empty;
-                return false;
-            }
-
-            public bool TryGetSpan(int index, out ReadOnlySpan<char> value)
-            {
-                if (TryGetMemory(index, out var memory))
-                {
-                    value = memory.Span;
-                    return true;
-                }
-
-                value = ReadOnlySpan<char>.Empty;
-                return false;
-            }
-
-            public override string ToString() => Raw;
-        }
-
-        internal sealed class ReadLineSpanOptimized : ICsvLineSpan
-        {
-            private readonly Dictionary<string, int> headerLookup;
-            private readonly CsvOptions options;
-            private readonly CsvMemoryOptions memoryOptions;
-            private readonly ReadOnlyMemory<char>[] headers;
-            private readonly ReadOnlyMemory<char> rawMemory;
-            internal IList<ReadOnlyMemory<char>>? rawFields;
-            private ReadOnlyMemory<char>[]? parsedValues;
-
-            public ReadLineSpanOptimized(ReadOnlyMemory<char>[] headers, Dictionary<string, int> headerLookup, int index, ReadOnlyMemory<char> raw, CsvOptions options, CsvMemoryOptions memoryOptions)
-            {
-                this.headerLookup = headerLookup;
-                this.options = options;
-                this.memoryOptions = memoryOptions;
-                this.headers = headers;
-                this.rawMemory = raw;
-                Index = index;
-            }
-
-            public string[] Headers => headers.Select(h => h.ToString()).ToArray();
-            public ReadOnlyMemory<char>[] HeadersMemory => headers;
-            public ReadOnlySpan<char> HeadersSpan => throw new NotSupportedException("HeadersSpan not supported for array access. Use GetSpan(int) or GetMemory(int) for individual headers.");
-
-            public string Raw => rawMemory.ToString();
-            public ReadOnlyMemory<char> RawMemory => rawMemory;
-            public ReadOnlySpan<char> RawSpan => rawMemory.Span;
-
-            public int Index { get; }
-            public int ColumnCount => ParsedValues.Length;
-
-            public bool HasColumn(string name) => headerLookup.ContainsKey(name);
-
-            public bool LineHasColumn(string name)
-            {
-                if (!headerLookup.TryGetValue(name, out var index))
-                    return false;
-
-                return RawFields.Count > index;
-            }
-
-            internal IList<ReadOnlyMemory<char>> RawFields => rawFields ??= SplitLineOptimized(rawMemory, options, memoryOptions, headers.Length);
-
-            public string[] Values => ParsedValues.Select(v => v.ToString()).ToArray();
-            public ReadOnlyMemory<char>[] ValuesMemory => ParsedValues;
-            public ReadOnlySpan<char> ValuesSpan => throw new NotSupportedException("ValuesSpan not supported for array access. Use GetSpan(int) or GetMemory(int) for individual values.");
-
-            private ReadOnlyMemory<char>[] ParsedValues
-            {
-                get
-                {
-                    if (parsedValues == null)
-                    {
-                        var raw = RawFields;
-
-                        if (options.ValidateColumnCount && raw.Count != Headers.Length)
-                            throw new InvalidOperationException($"Expected {Headers.Length}, got {raw.Count} columns.");
-
-                        parsedValues = TrimOptimized(raw, options, memoryOptions);
-                    }
-
-                    return parsedValues;
-                }
-            }
-
-            string ICsvLine.this[string name] => GetSpan(name).ToString();
-            string ICsvLine.this[int index] => GetSpan(index).ToString();
-
-            public ReadOnlyMemory<char> GetMemory(string name)
-            {
-                if (!headerLookup.TryGetValue(name, out var index))
-                {
-                    if (options.ReturnEmptyForMissingColumn)
-                        return ReadOnlyMemory<char>.Empty;
-
-                    throw new ArgumentOutOfRangeException(nameof(name), name, $"Header '{name}' does not exist. Expected one of {string.Join("; ", Headers)}");
-                }
-
-                try
-                {
-                    return ParsedValues[index];
-                }
-                catch (IndexOutOfRangeException)
-                {
-                    throw new InvalidOperationException($"Invalid row, missing {name} header, expected {Headers.Length} columns, got {ParsedValues.Length} columns.");
-                }
-            }
-
-            public ReadOnlyMemory<char> GetMemory(int index) => ParsedValues[index];
-
-            public ReadOnlySpan<char> GetSpan(string name) => GetMemory(name).Span;
-            public ReadOnlySpan<char> GetSpan(int index) => GetMemory(index).Span;
-
-            public bool TryGetMemory(string name, out ReadOnlyMemory<char> value)
-            {
-                if (headerLookup.TryGetValue(name, out var index) && index < ParsedValues.Length)
-                {
-                    value = ParsedValues[index];
-                    return true;
-                }
-
-                value = ReadOnlyMemory<char>.Empty;
-                return false;
-            }
-
-            public bool TryGetMemory(int index, out ReadOnlyMemory<char> value)
-            {
-                if (index >= 0 && index < ParsedValues.Length)
-                {
-                    value = ParsedValues[index];
-                    return true;
-                }
-
-                value = ReadOnlyMemory<char>.Empty;
-                return false;
-            }
-
-            public bool TryGetSpan(string name, out ReadOnlySpan<char> value)
-            {
-                if (TryGetMemory(name, out var memory))
-                {
-                    value = memory.Span;
-                    return true;
-                }
-
-                value = ReadOnlySpan<char>.Empty;
-                return false;
-            }
-
-            public bool TryGetSpan(int index, out ReadOnlySpan<char> value)
-            {
-                if (TryGetMemory(index, out var memory))
-                {
-                    value = memory.Span;
-                    return true;
-                }
-
-                value = ReadOnlySpan<char>.Empty;
-                return false;
-            }
-
-            public override string ToString() => Raw;
-        }
 
         private static IList<ReadOnlyMemory<char>> SplitLineOptimized(ReadOnlyMemory<char> line, CsvOptions options, CsvMemoryOptions memoryOptions, int? capacity = null)
         {

--- a/docs/Architecture-Deepening-Candidates.md
+++ b/docs/Architecture-Deepening-Candidates.md
@@ -1,0 +1,150 @@
+# Architecture Deepening Candidates
+
+> Output of an `improve-codebase-architecture` exploration pass (John Ousterhout,
+> *A Philosophy of Software Design* — deep modules: small interface hiding a large
+> implementation; shallow modules leak complexity to callers).
+>
+> Date: 2026-06-20. Branch: `master`.
+
+## Binding constraint: the public API is frozen
+
+`ICsvLine`, `ICsvLineSpan`, `ICsvLineFromMemory` and every `CsvReader` / `CsvWriter`
+static method are fixed. **Every candidate below is an internal-only refactor** — the
+row classes are `internal sealed`, the parsing engine is `private`, `CsvLineSplitter`
+is `internal`. All deepenings are safe under the freeze.
+
+All four candidates are **dependency category: In-process** (pure computation; the only
+I/O is already hidden behind `ILineSource` / `IAsyncLineSource`). So each is directly
+mergeable and testable at the boundary with no test stand-ins.
+
+---
+
+## Candidate 1 — Collapse the four near-identical row classes
+
+**Cluster:** `ReadLine` (`CsvReader.cs:448-545`), `ReadLineSpan` (`549-688`),
+`ReadLineSpanOptimized` (`690-832`), `ReadLineFromMemory` (`FromMemory.cs:22-107`).
+~465 lines.
+
+**Why coupled:** All four own *the same concept* — "a parsed row: lazy `RawFields` →
+validate → `ParsedValues` → access by name/index." They differ only in backing store
+(`string` Raw vs `ReadOnlyMemory<char>` raw) and which split helper they call.
+`ReadLineSpan` and `ReadLineSpanOptimized` are ~140 lines each and differ almost solely
+in storage. Validation, the `ReturnEmptyForMissingColumn` branch, and **three
+error-message string literals** are copy-pasted 3–4× each.
+
+**Test impact:** `EngineUnificationTests.cs` (675 lines, 20 tests) exists *only* to prove
+the five read paths emit identical `Headers`/`Values`/`Raw`; `IssuesTests` #114 re-tests
+one scenario across 3 paths. Those collapse to one row-boundary suite + thin per-path
+wiring tests. No test constructs a row class directly today.
+
+**Note:** Flagged in project memory as *"four near-identical row classes persist;
+refactoring deferred."* Highest duplication, lowest risk.
+
+---
+
+## Candidate 2 — Extract a single Field Codec (escape ⇄ unescape ⇄ quote-decision)
+
+**Cluster:** Read side — `Trim` (`CsvReader.cs:346`), `TrimOptimized` (`840`),
+`StringHelpers.Unescape`, `CsvLineSplitter` (`Split` + `IsUnterminatedQuotedValue` +
+`IsAtFieldOpen`). Write side — **five** independent "decide-if-quote + double-the-quotes"
+implementations: `WriteLine` (`CsvWriter.cs:484`, via `.Replace`), `WriteLineAsync`
+(`528`, manual segments), `WriteCellMemory` (`623`), `WriteCellToBuffer` (`682`),
+`CsvBufferWriter.WriteCell` (`104`).
+
+**Why coupled:** One contract — *"what makes a field need quoting, and how are quotes
+escaped"* — expressed **seven times, in two opposite directions, sharing zero code.** The
+quote-trigger set (`"`, separator, `\n`, `\r`, `'`) is re-typed in all five writers; the
+inverse unescape rules live scattered across reader `Trim`/`TrimOptimized`/splitter.
+Reader and writer can silently drift out of round-trip symmetry.
+
+**Test impact:** `RegexEliminationTests` (9) + `RegexPerformanceTests` (2) directly test
+the internal `IsUnterminatedQuotedValue`; writer escaping is tested *only* indirectly via
+`WriterTests` (41). A codec gets exhaustive direct boundary tests — including
+`unescape(escape(x)) == x`, which no test asserts today.
+
+**Note:** Deepest, most cross-cutting, highest payoff — also the largest surface. The
+write-only sub-slice (collapse the 5 writer impls) is a viable smaller scope.
+
+---
+
+## Candidate 3 — Unify the sync/async parsing engine
+
+**Cluster:** `Enumerate` (`CsvReader.Engine.cs:246-344`) and `EnumerateAsync`
+(`347-451`). ~99 lines each.
+
+**Why coupled:** Byte-for-byte the same orchestration — `RowsToSkip`/`SkipRow`,
+`InitializeOptions`, the HeaderAbsent multiline pre-pass, `GetHeaders` vs
+`CreateDefaultHeaders`, `CreateHeaderLookup` + the duplicate-header catch, alias
+resolution, and the multiline-continuation loop — duplicated verbatim. The *only* real
+difference is one line: `source.TryReadLine(...)` vs `await source.TryReadLineAsync(...)`.
+
+**Test impact:** `EngineUnificationTests` already asserts sync/async parity — dedup makes
+that parity *structural* rather than test-enforced.
+
+**Note:** Highest-value logic to unify, but the **hardest in C#** — sync/async can't share
+a body without a pull-model state machine or sync-over-async. A genuine "design it twice"
+case.
+
+---
+
+## Candidate 4 — Retire the `options.Splitter` mutable side-channel
+
+**Cluster:** `CsvOptions.Splitter` (`CsvOptions.cs:103`, internal mutable on a public
+class), `InitializeOptions` (`CsvReader.cs:333`), and the
+`Debug.Assert(options.Splitter == null)` reuse-detector in `Enumerate`/`EnumerateAsync`.
+
+**Why coupled:** The splitter is stitched onto the options object as hidden mutable state,
+then "don't reuse options" is enforced via a Debug-only assert — a *"define errors out of
+existence"* violation. `CsvLineSplitter` itself is shallow (holds only `separator`,
+re-reads everything else from `options` per call; `IsUnterminatedQuotedValue` is static).
+
+**Test impact:** Minimal — correctness/clarity cleanup that removes a footgun.
+
+**Note:** Smallest scope. Largely subsumed by Candidate 2 (the splitter is the read-side
+of the codec). Best as a rider on #2.
+
+---
+
+## How they relate
+
+- **#1** (row data-access shape) and **#2** (field byte-level semantics) are the two big
+  wins and are largely independent.
+- **#3** is high-value but design-hard.
+- **#4** folds into #2.
+
+**Recommendation:** **#1 is the cleanest first move** (explicitly-deferred, lowest risk,
+collapses the largest test-duplication). **#2 is the deepest** (true reader/writer
+symmetry; write-side currently untested in isolation).
+
+---
+
+> **Note:** Candidate 3 (engine unification) was already shipped as #118 — that RFC's
+> `Enumerate<TSource, TFactory, TRow>` is why `CsvReader.Engine.cs` exists. Candidate 1 is
+> its row-side sequel.
+
+---
+
+## Selected for deep exploration: **Candidate 1** → RFC [#132](https://github.com/stevehansen/csv/issues/132)
+
+A parallel exploration produced **four divergent interface designs**, each adversarially
+judged against the four hard constraints (API-freeze, multi-target, allocation parity, AOT):
+
+| Design | Shape | ns2.0 | alloc | score |
+|---|---|:--:|:--:|:--:|
+| 1. minimal-surface | `CsvRow<TStore,TBacking>` (2 type params), all 3 interfaces | ✗ `null` | ✓ | 7 |
+| 2. max-flexibility | core + 3 view-wrapper classes (open/closed) | ✗ | ✓⁻ (extra obj/row) | 5 |
+| 3. common-caller-first | two-tier: `ReadLine` as-is + memory `CsvRow<TStrategy>` | ✓ | ✗ (`Raw` realloc) | 7 |
+| 4. zero-alloc-first | one `CsvRow<TPolicy>`, `MemoryText`-backed, union-of-interfaces | ✗ `null` | ✓ | 6 |
+
+**Cross-cutting findings (all four judges confirmed):** one class implementing
+`ICsvLineSpan` **and** `ICsvLineFromMemory` is legal via *explicit* interface implementation
+(indexers differ only by return type); `IEnumerable<out T>` covariance returns one closed
+generic as any element type without a wrapper; the struct-generic strategy preserves JIT
+devirtualization. **The constraint that broke 3 of 4:** `return default!` is `null` on
+netstandard2.0, silently regressing `ReturnEmptyForMissingColumn` from `""` to `null`.
+
+**Chosen: hybrid — #4 spine + the discipline #3 got right.** Single generic
+`CsvLine<TPolicy>`, hardened with three corrections (empty-value `"".AsMemory()`,
+internal `parsedValues` + `GetBlock` initializer, cached original `rawString` for
+zero-alloc `Raw`). Full duplication collapse (~465 → ~210 LOC), all constraints met.
+See [#132](https://github.com/stevehansen/csv/issues/132) for the full RFC.


### PR DESCRIPTION
Implements #132 — the row-side sequel to #118.

## What
The four near-identical row classes the engine factories produced — `ReadLine`, `ReadLineSpan`, `ReadLineSpanOptimized`, `ReadLineFromMemory` (~465 LOC) — collapse into one `internal sealed class CsvLine<TPolicy>` (184 LOC). They owned the same concept (lazy `split → validate → trim → lookup-with-policy`) and differed only in backing store and which split/trim they called. That seam is now a value-type strategy `TPolicy : struct, ITrimSplit`:

- `DefaultTrimSplit` — all targets (the ns2.0, net8 string, and FromMemory paths)
- `OptimizedTrimSplit` — net8-only, holds the `CsvMemoryOptions` for the ArrayPool path

Both are JIT-devirtualized exactly like the existing `IRowFactory` structs — no virtual dispatch, AOT/trim-safe.

On net8 the single class implements the **union** of all three frozen interfaces; the `Headers`/`Values`/`Raw`/`this[]` members that collide only by return type (`string` vs `ReadOnlyMemory<char>`) are disambiguated by **explicit interface implementation**. On netstandard2.0 it implements only `ICsvLine` + `DefaultTrimSplit`. `IEnumerable<out T>` covariance adapts the closed generic to each public return type — no wrapper, no cast.

## Internal-only — public API frozen
No diff to `ICsvLine` / `ICsvLineSpan` / `ICsvLineFromMemory` or any `CsvReader` static method. The three previously-duplicated error strings are now single-copy with byte-identical runtime output.

## Three hardening fixes (from the adversarial design review)
1. **Empty value** uses `"".AsMemory()`, not `default!` — on ns2.0 (`MemoryText`=`string`) `default` is `null` and would silently regress `ReturnEmptyForMissingColumn` from `""` to `null`.
2. **`parsedValues` stays internal** so `GetBlock` pre-seeds sub-line values via the object initializer (otherwise the row re-splits a synthesized `Raw` and yields wrong columns).
3. **`Raw` zero-alloc parity** — original line cached in `rawString`; `Raw => rawString ?? rawMemory.ToString()` keeps `Raw` allocation-free on the `TextReader` paths while the memory paths still materialize on demand.

## Verification
- **Build:** clean on net8.0 / netstandard2.0 / net9.0, 0 errors, **0 new warnings** (the pre-existing `options.Splitter` CS8602s are unchanged — confirmed against the baseline tree).
- **Tests:** `193/193` passing. Adds `Csv.Tests/RowUnificationTests.cs` (10 tests) pinning all three fixes, incl. a `MemoryMarshal.TryGetString` + `Assert.AreSame` zero-copy aliasing check for FIX 3. Existing `EngineUnificationTests` cross-path identity assertions now verify a *structural* guarantee rather than papering over four hand-written classes.
- **Review (code quality):** Looks-good — member-by-member behavior parity vs the four originals confirmed; no Blocking/Should-fix.
- **Verify (spec conformance):** Conforms on all 14 requirements.

Also includes `docs/Architecture-Deepening-Candidates.md` — the exploration write-up that produced this RFC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)